### PR TITLE
telega.el: added guard for "print-circle" variable

### DIFF
--- a/telega-server.el
+++ b/telega-server.el
@@ -166,8 +166,9 @@ Raise error if not found"
 
 (defun telega-server--send (sexp)
   "Send SEXP to telega-server."
-  (let ((value (prin1-to-string (telega--tl-pack sexp)))
-        (proc (telega-server--proc)))
+  (let* ((print-circle nil)
+         (value (prin1-to-string (telega--tl-pack sexp)))
+         (proc (telega-server--proc)))
     (assert (process-live-p proc) nil "telega-server is not running")
     (telega-debug "OUTPUT: %d %s" (string-bytes value) value)
 


### PR DESCRIPTION
We should disable linking sexp substructures, because
it breaks parsing on server side.