### PR TITLE
[fix] Force utf-8 while starting telega server.

### DIFF
--- a/telega-server.el
+++ b/telega-server.el
@@ -337,7 +337,8 @@ If CALLBACK is specified return `:@extra' value used for the call."
                           proc-args)))
         (set-process-query-on-exit-flag proc nil)
         (set-process-sentinel proc #'telega-server--sentinel)
-        (set-process-filter proc #'telega-server--filter))))
+        (set-process-filter proc #'telega-server--filter)
+        (set-process-coding-system proc 'utf-8 'utf-8))))
   (current-buffer))
 
 (defun telega-server-kill ()


### PR DESCRIPTION
If user change default coding system, telega may failed to send non-ASCII
message and core dumped. This PR can fix this.

How to reproduce:

-  `(set-default-coding-systems 'gbk)`, or any other except utf-8 series.
- Start telega and send any message contains non-ASCII character.
- telega-server core dumped.

----

#