### PR TITLE
Tty compatibility

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -2545,8 +2545,11 @@ If PREVIEW-P is non-nil, then generate preview image."
   "Attach FILENAME as photo to the current input."
   (interactive (list (read-file-name "Photo: ")))
   (let ((ifile (telega-chatbuf--gen-input-file filename 'Photo t))
-        (img-size (image-size
-                   (create-image filename 'imagemagick nil :scale 1.0) t)))
+        (img-size
+         (if (display-graphic-p)
+             (image-size
+              (create-image filename 'imagemagick nil :scale 1.0) t)
+           (cons 0 0))))
     (telega-chatbuf-input-insert
      (list :@type "inputMessagePhoto"
            :photo ifile

--- a/telega-media.el
+++ b/telega-media.el
@@ -572,43 +572,45 @@ File is specified with FILE-SPEC."
          (name (if (eq (telega--tl-type chat-or-user) 'user)
                    (telega-user--name chat-or-user)
                  (telega-chat-title chat-or-user))))
-    (if (telega-file-exists-p photofile)
-        (let ((img-type (image-type-from-file-name photofile))
-              (clip (telega-svg-clip-path svg "clip")))
-          (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
-          (svg-embed svg photofile
-                     (format "image/%S" img-type)
-                     nil
-                     :x (/ (- xw ch) 2) :y (/ margin 2)
-                     :width ch :height ch
-                     :clip-path "url(#clip)"))
-
-      ;; Draw initials
-      (let ((fsz (/ ch 2))
-            (color (if (eq (telega--tl-type chat-or-user) 'user)
-                       (telega-user-color chat-or-user)
-                     (telega-chat-color chat-or-user))))
-        (svg-gradient svg "cgrad" 'linear
-                      (list (cons 0 (cadr color)) (cons ch (caddr color))))
-        (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
-        (svg-text svg (substring name 0 1)
-                  :font-size (/ ch 2)
-                  :font-weight "bold"
-                  :fill "white"
-                  :font-family "monospace"
-                  ;; XXX insane X/Y calculation
-                  :x (- (/ xw 2) (/ fsz 3))
-                  :y (+ (/ fsz 3) (/ cfull 2)))))
 
     (if (display-graphic-p)
-        (svg-image svg :scale 1.0
-                   :width xw :height xh
-                   :ascent 'center
-                   :mask 'heuristic
-                   ;; Correct text for tty-only avatar display
-                   :telega-text (list (concat "(" (substring name 0 1) ")"
-                                              (make-string aw-chars-3 ?\u00A0))
-                                      (make-string (+ 3 aw-chars-3) ?\u00A0)))
+        (progn
+          (if (telega-file-exists-p photofile)
+              (let ((img-type (image-type-from-file-name photofile))
+                    (clip (telega-svg-clip-path svg "clip")))
+                (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
+                (svg-embed svg photofile
+                           (format "image/%S" img-type)
+                           nil
+                           :x (/ (- xw ch) 2) :y (/ margin 2)
+                           :width ch :height ch
+                           :clip-path "url(#clip)"))
+
+            ;; Draw initials
+            (let ((fsz (/ ch 2))
+                  (color (if (eq (telega--tl-type chat-or-user) 'user)
+                             (telega-user-color chat-or-user)
+                           (telega-chat-color chat-or-user))))
+              (svg-gradient svg "cgrad" 'linear
+                            (list (cons 0 (cadr color)) (cons ch (caddr color))))
+              (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
+              (svg-text svg (substring name 0 1)
+                        :font-size (/ ch 2)
+                        :font-weight "bold"
+                        :fill "white"
+                        :font-family "monospace"
+                        ;; XXX insane X/Y calculation
+                        :x (- (/ xw 2) (/ fsz 3))
+                        :y (+ (/ fsz 3) (/ cfull 2)))))
+          
+          (svg-image svg :scale 1.0
+                     :width xw :height xh
+                     :ascent 'center
+                     :mask 'heuristic
+                     ;; Correct text for tty-only avatar display
+                     :telega-text (list (concat "(" (substring name 0 1) ")"
+                                                (make-string aw-chars-3 ?\u00A0))
+                                        (make-string (+ 3 aw-chars-3) ?\u00A0))))
       (list 'dummy-image
             :scale 1.0
             :width xw :height xh

--- a/telega-media.el
+++ b/telega-media.el
@@ -548,7 +548,6 @@ File is specified with FILE-SPEC."
 
 (defun telega-avatar--create-image (chat-or-user file)
   "Create image for CHAT-OR-USER avatar."
-  (if (display-graphic-p)
   (let* ((photofile (telega--tl-get file :local :path))
          (cfactor (or (car telega-avatar-factors) 0.9))
          (mfactor (or (cdr telega-avatar-factors) 0.1))
@@ -591,58 +590,15 @@ File is specified with FILE-SPEC."
                   :x (- (/ xw 2) (/ fsz 3))
                   :y (+ (/ fsz 3) (/ cfull 2)))))
 
-    (svg-image svg :scale 1.0
-               :width xw :height xh
-               :ascent 'center
-               :mask 'heuristic
-               ;; Correct text for tty-only avatar display
-               :telega-text (list (concat "(" (substring name 0 1) ")"
-                                          (make-string aw-chars-3 ?\u00A0))
-                                  (make-string (+ 3 aw-chars-3) ?\u00A0))
-               ))
-
-     (let* ((photofile (telega--tl-get file :local :path))
-           (cfactor (or (car telega-avatar-factors) 0.9))
-           (mfactor (or (cdr telega-avatar-factors) 0.1))
-           (xh (telega-chars-xheight 2))
-           (margin (* mfactor xh))
-           (ch (* cfactor xh))
-           (cfull (+ ch margin))
-           (aw-chars (telega-chars-in-width cfull))
-           (aw-chars-3 (if (> aw-chars 3) (- aw-chars 3) 0))
-           (xw (telega-chars-xwidth aw-chars))
-           (svg (svg-create xw xh))
-           (name (if (eq (telega--tl-type chat-or-user) 'user)
-                     (telega-user--name chat-or-user)
-                   (telega-chat-title chat-or-user))))
-      (if (telega-file-exists-p photofile)
-          (let ((img-type (image-type-from-file-name photofile))
-                (clip (telega-svg-clip-path svg "clip")))
-            (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
-            (svg-embed svg photofile
-                       (format "image/%S" img-type)
-                       nil
-                       :x (/ (- xw ch) 2) :y (/ margin 2)
-                       :width ch :height ch
-                       :clip-path "url(#clip)"))
-
-        ;; Draw initials
-        (let ((fsz (/ ch 2))
-              (color (if (eq (telega--tl-type chat-or-user) 'user)
-                         (telega-user-color chat-or-user)
-                       (telega-chat-color chat-or-user))))
-          (svg-gradient svg "cgrad" 'linear
-                        (list (cons 0 (cadr color)) (cons ch (caddr color))))
-          (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
-          (svg-text svg (substring name 0 1)
-                    :font-size (/ ch 2)
-                    :font-weight "bold"
-                    :fill "white"
-                    :font-family "monospace"
-                    ;; XXX insane X/Y calculation
-                    :x (- (/ xw 2) (/ fsz 3))
-                    :y (+ (/ fsz 3) (/ cfull 2)))))
-
+    (if (display-graphic-p)
+        (svg-image svg :scale 1.0
+                   :width xw :height xh
+                   :ascent 'center
+                   :mask 'heuristic
+                   ;; Correct text for tty-only avatar display
+                   :telega-text (list (concat "(" (substring name 0 1) ")"
+                                              (make-string aw-chars-3 ?\u00A0))
+                                      (make-string (+ 3 aw-chars-3) ?\u00A0)))
       (list 'dummy-image
             :scale 1.0
             :width xw :height xh

--- a/telega-media.el
+++ b/telega-media.el
@@ -561,7 +561,16 @@ File is specified with FILE-SPEC."
          (svg (svg-create xw xh))
          (name (if (eq (telega--tl-type chat-or-user) 'user)
                    (telega-user--name chat-or-user)
-                 (telega-chat-title chat-or-user))))
+                 (telega-chat-title chat-or-user)))
+         (image-properties
+          (list :scale 1.0
+                :width xw :height xh
+                :ascent 'center
+                :mask 'heuristic
+                ;; Correct text for tty-only avatar display
+                :telega-text (list (concat "(" (substring name 0 1) ")"
+                                           (make-string aw-chars-3 ?\u00A0))
+                                   (make-string (+ 3 aw-chars-3) ?\u00A0)))))
 
     (if (display-graphic-p)
         (progn
@@ -593,23 +602,8 @@ File is specified with FILE-SPEC."
                         :x (- (/ xw 2) (/ fsz 3))
                         :y (+ (/ fsz 3) (/ cfull 2)))))
           
-          (svg-image svg :scale 1.0
-                     :width xw :height xh
-                     :ascent 'center
-                     :mask 'heuristic
-                     ;; Correct text for tty-only avatar display
-                     :telega-text (list (concat "(" (substring name 0 1) ")"
-                                                (make-string aw-chars-3 ?\u00A0))
-                                        (make-string (+ 3 aw-chars-3) ?\u00A0))))
-      (list 'dummy-image
-            :scale 1.0
-            :width xw :height xh
-            :ascent 'center
-            :mask 'heuristic
-            ;; Correct text for tty-only avatar display
-            :telega-text (list (concat "(" (substring name 0 1) ")"
-                                       (make-string aw-chars-3 ?\u00A0))
-                               (make-string (+ 3 aw-chars-3) ?\u00A0))))))
+          (apply #'svg-image svg image-properties))
+      (cons 'dummy-image image-properties))))
 
 (defun telega-symbol-emojify (emoji)
   "Attach `display' property with emoji svg to EMOJI string.

--- a/telega-media.el
+++ b/telega-media.el
@@ -548,6 +548,7 @@ File is specified with FILE-SPEC."
 
 (defun telega-avatar--create-image (chat-or-user file)
   "Create image for CHAT-OR-USER avatar."
+  (if (display-graphic-p)
   (let* ((photofile (telega--tl-get file :local :path))
          (cfactor (or (car telega-avatar-factors) 0.9))
          (mfactor (or (cdr telega-avatar-factors) 0.1))
@@ -598,7 +599,59 @@ File is specified with FILE-SPEC."
                :telega-text (list (concat "(" (substring name 0 1) ")"
                                           (make-string aw-chars-3 ?\u00A0))
                                   (make-string (+ 3 aw-chars-3) ?\u00A0))
-               )))
+               ))
+
+     (let* ((photofile (telega--tl-get file :local :path))
+           (cfactor (or (car telega-avatar-factors) 0.9))
+           (mfactor (or (cdr telega-avatar-factors) 0.1))
+           (xh (telega-chars-xheight 2))
+           (margin (* mfactor xh))
+           (ch (* cfactor xh))
+           (cfull (+ ch margin))
+           (aw-chars (telega-chars-in-width cfull))
+           (aw-chars-3 (if (> aw-chars 3) (- aw-chars 3) 0))
+           (xw (telega-chars-xwidth aw-chars))
+           (svg (svg-create xw xh))
+           (name (if (eq (telega--tl-type chat-or-user) 'user)
+                     (telega-user--name chat-or-user)
+                   (telega-chat-title chat-or-user))))
+      (if (telega-file-exists-p photofile)
+          (let ((img-type (image-type-from-file-name photofile))
+                (clip (telega-svg-clip-path svg "clip")))
+            (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
+            (svg-embed svg photofile
+                       (format "image/%S" img-type)
+                       nil
+                       :x (/ (- xw ch) 2) :y (/ margin 2)
+                       :width ch :height ch
+                       :clip-path "url(#clip)"))
+
+        ;; Draw initials
+        (let ((fsz (/ ch 2))
+              (color (if (eq (telega--tl-type chat-or-user) 'user)
+                         (telega-user-color chat-or-user)
+                       (telega-chat-color chat-or-user))))
+          (svg-gradient svg "cgrad" 'linear
+                        (list (cons 0 (cadr color)) (cons ch (caddr color))))
+          (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
+          (svg-text svg (substring name 0 1)
+                    :font-size (/ ch 2)
+                    :font-weight "bold"
+                    :fill "white"
+                    :font-family "monospace"
+                    ;; XXX insane X/Y calculation
+                    :x (- (/ xw 2) (/ fsz 3))
+                    :y (+ (/ fsz 3) (/ cfull 2)))))
+
+      (list 'dummy-image
+            :scale 1.0
+            :width xw :height xh
+            :ascent 'center
+            :mask 'heuristic
+            ;; Correct text for tty-only avatar display
+            :telega-text (list (concat "(" (substring name 0 1) ")"
+                                       (make-string aw-chars-3 ?\u00A0))
+                               (make-string (+ 3 aw-chars-3) ?\u00A0))))))
 
 (defun telega-symbol-emojify (emoji)
   "Attach `display' property with emoji svg to EMOJI string.

--- a/telega-media.el
+++ b/telega-media.el
@@ -583,7 +583,7 @@ File is specified with FILE-SPEC."
                                    (make-string (+ 3 aw-chars-3) ?\u00A0)))))
 
     (if (display-graphic-p)
-        (progn
+        (let ((svg (svg-create xw xh)))
           (if (telega-file-exists-p photofile)
               (let ((img-type (image-type-from-file-name photofile))
                     (clip (telega-svg-clip-path svg "clip")))

--- a/telega-media.el
+++ b/telega-media.el
@@ -559,7 +559,6 @@ File is specified with FILE-SPEC."
 
 (defun telega-avatar--create-image (chat-or-user file)
   "Create image for CHAT-OR-USER avatar."
-  (if (display-graphic-p)
   (let* ((photofile (telega--tl-get file :local :path))
          (cfactor (or (car telega-avatar-factors) 0.9))
          (mfactor (or (cdr telega-avatar-factors) 0.1))
@@ -601,58 +600,15 @@ File is specified with FILE-SPEC."
                   :x (- (/ xw 2) (/ fsz 3))
                   :y (+ (/ fsz 3) (/ cfull 2)))))
 
-    (svg-image svg :scale 1.0
-               :width xw :height xh
-               :ascent 'center
-               :mask 'heuristic
-               ;; Correct text for tty-only avatar display
-               :telega-text (list (concat "(" (substring name 0 1) ")"
-                                          (make-string aw-chars-3 ?\u00A0))
-                                  (make-string (+ 3 aw-chars-3) ?\u00A0))
-               ))
-
-     (let* ((photofile (telega--tl-get file :local :path))
-           (cfactor (or (car telega-avatar-factors) 0.9))
-           (mfactor (or (cdr telega-avatar-factors) 0.1))
-           (xh (telega-chars-xheight 2))
-           (margin (* mfactor xh))
-           (ch (* cfactor xh))
-           (cfull (+ ch margin))
-           (aw-chars (telega-chars-in-width cfull))
-           (aw-chars-3 (if (> aw-chars 3) (- aw-chars 3) 0))
-           (xw (telega-chars-xwidth aw-chars))
-           (svg (svg-create xw xh))
-           (name (if (eq (telega--tl-type chat-or-user) 'user)
-                     (telega-user--name chat-or-user)
-                   (telega-chat-title chat-or-user))))
-      (if (telega-file-exists-p photofile)
-          (let ((img-type (image-type-from-file-name photofile))
-                (clip (telega-svg-clip-path svg "clip")))
-            (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
-            (svg-embed svg photofile
-                       (format "image/%S" img-type)
-                       nil
-                       :x (/ (- xw ch) 2) :y (/ margin 2)
-                       :width ch :height ch
-                       :clip-path "url(#clip)"))
-
-        ;; Draw initials
-        (let ((fsz (/ ch 2))
-              (color (if (eq (telega--tl-type chat-or-user) 'user)
-                         (telega-user-color chat-or-user)
-                       (telega-chat-color chat-or-user))))
-          (svg-gradient svg "cgrad" 'linear
-                        (list (cons 0 (cadr color)) (cons ch (caddr color))))
-          (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
-          (svg-text svg (substring name 0 1)
-                    :font-size (/ ch 2)
-                    :font-weight "bold"
-                    :fill "white"
-                    :font-family "monospace"
-                    ;; XXX insane X/Y calculation
-                    :x (- (/ xw 2) (/ fsz 3))
-                    :y (+ (/ fsz 3) (/ cfull 2)))))
-
+    (if (display-graphic-p)
+        (svg-image svg :scale 1.0
+                   :width xw :height xh
+                   :ascent 'center
+                   :mask 'heuristic
+                   ;; Correct text for tty-only avatar display
+                   :telega-text (list (concat "(" (substring name 0 1) ")"
+                                              (make-string aw-chars-3 ?\u00A0))
+                                      (make-string (+ 3 aw-chars-3) ?\u00A0)))
       (list 'dummy-image
             :scale 1.0
             :width xw :height xh

--- a/telega-media.el
+++ b/telega-media.el
@@ -571,7 +571,16 @@ File is specified with FILE-SPEC."
          (xw (telega-chars-xwidth aw-chars))
          (name (if (eq (telega--tl-type chat-or-user) 'user)
                    (telega-user--name chat-or-user)
-                 (telega-chat-title chat-or-user))))
+                 (telega-chat-title chat-or-user)))
+         (image-properties
+          (list :scale 1.0
+                :width xw :height xh
+                :ascent 'center
+                :mask 'heuristic
+                ;; Correct text for tty-only avatar display
+                :telega-text (list (concat "(" (substring name 0 1) ")"
+                                           (make-string aw-chars-3 ?\u00A0))
+                                   (make-string (+ 3 aw-chars-3) ?\u00A0)))))
 
     (if (display-graphic-p)
         (progn
@@ -603,23 +612,8 @@ File is specified with FILE-SPEC."
                         :x (- (/ xw 2) (/ fsz 3))
                         :y (+ (/ fsz 3) (/ cfull 2)))))
           
-          (svg-image svg :scale 1.0
-                     :width xw :height xh
-                     :ascent 'center
-                     :mask 'heuristic
-                     ;; Correct text for tty-only avatar display
-                     :telega-text (list (concat "(" (substring name 0 1) ")"
-                                                (make-string aw-chars-3 ?\u00A0))
-                                        (make-string (+ 3 aw-chars-3) ?\u00A0))))
-      (list 'dummy-image
-            :scale 1.0
-            :width xw :height xh
-            :ascent 'center
-            :mask 'heuristic
-            ;; Correct text for tty-only avatar display
-            :telega-text (list (concat "(" (substring name 0 1) ")"
-                                       (make-string aw-chars-3 ?\u00A0))
-                               (make-string (+ 3 aw-chars-3) ?\u00A0))))))
+          (apply #'svg-image svg image-properties))
+      (cons 'dummy-image image-properties))))
 
 (defun telega-symbol-emojify (emoji)
   "Attach `display' property with emoji svg to EMOJI string.

--- a/telega-media.el
+++ b/telega-media.el
@@ -562,43 +562,45 @@ File is specified with FILE-SPEC."
          (name (if (eq (telega--tl-type chat-or-user) 'user)
                    (telega-user--name chat-or-user)
                  (telega-chat-title chat-or-user))))
-    (if (telega-file-exists-p photofile)
-        (let ((img-type (image-type-from-file-name photofile))
-              (clip (telega-svg-clip-path svg "clip")))
-          (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
-          (svg-embed svg photofile
-                     (format "image/%S" img-type)
-                     nil
-                     :x (/ (- xw ch) 2) :y (/ margin 2)
-                     :width ch :height ch
-                     :clip-path "url(#clip)"))
-
-      ;; Draw initials
-      (let ((fsz (/ ch 2))
-            (color (if (eq (telega--tl-type chat-or-user) 'user)
-                       (telega-user-color chat-or-user)
-                     (telega-chat-color chat-or-user))))
-        (svg-gradient svg "cgrad" 'linear
-                      (list (cons 0 (cadr color)) (cons ch (caddr color))))
-        (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
-        (svg-text svg (substring name 0 1)
-                  :font-size (/ ch 2)
-                  :font-weight "bold"
-                  :fill "white"
-                  :font-family "monospace"
-                  ;; XXX insane X/Y calculation
-                  :x (- (/ xw 2) (/ fsz 3))
-                  :y (+ (/ fsz 3) (/ cfull 2)))))
 
     (if (display-graphic-p)
-        (svg-image svg :scale 1.0
-                   :width xw :height xh
-                   :ascent 'center
-                   :mask 'heuristic
-                   ;; Correct text for tty-only avatar display
-                   :telega-text (list (concat "(" (substring name 0 1) ")"
-                                              (make-string aw-chars-3 ?\u00A0))
-                                      (make-string (+ 3 aw-chars-3) ?\u00A0)))
+        (progn
+          (if (telega-file-exists-p photofile)
+              (let ((img-type (image-type-from-file-name photofile))
+                    (clip (telega-svg-clip-path svg "clip")))
+                (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
+                (svg-embed svg photofile
+                           (format "image/%S" img-type)
+                           nil
+                           :x (/ (- xw ch) 2) :y (/ margin 2)
+                           :width ch :height ch
+                           :clip-path "url(#clip)"))
+
+            ;; Draw initials
+            (let ((fsz (/ ch 2))
+                  (color (if (eq (telega--tl-type chat-or-user) 'user)
+                             (telega-user-color chat-or-user)
+                           (telega-chat-color chat-or-user))))
+              (svg-gradient svg "cgrad" 'linear
+                            (list (cons 0 (cadr color)) (cons ch (caddr color))))
+              (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
+              (svg-text svg (substring name 0 1)
+                        :font-size (/ ch 2)
+                        :font-weight "bold"
+                        :fill "white"
+                        :font-family "monospace"
+                        ;; XXX insane X/Y calculation
+                        :x (- (/ xw 2) (/ fsz 3))
+                        :y (+ (/ fsz 3) (/ cfull 2)))))
+          
+          (svg-image svg :scale 1.0
+                     :width xw :height xh
+                     :ascent 'center
+                     :mask 'heuristic
+                     ;; Correct text for tty-only avatar display
+                     :telega-text (list (concat "(" (substring name 0 1) ")"
+                                                (make-string aw-chars-3 ?\u00A0))
+                                        (make-string (+ 3 aw-chars-3) ?\u00A0))))
       (list 'dummy-image
             :scale 1.0
             :width xw :height xh

--- a/telega-media.el
+++ b/telega-media.el
@@ -559,6 +559,7 @@ File is specified with FILE-SPEC."
 
 (defun telega-avatar--create-image (chat-or-user file)
   "Create image for CHAT-OR-USER avatar."
+  (if (display-graphic-p)
   (let* ((photofile (telega--tl-get file :local :path))
          (cfactor (or (car telega-avatar-factors) 0.9))
          (mfactor (or (cdr telega-avatar-factors) 0.1))
@@ -571,49 +572,96 @@ File is specified with FILE-SPEC."
          (xw (telega-chars-xwidth aw-chars))
          (name (if (eq (telega--tl-type chat-or-user) 'user)
                    (telega-user--name chat-or-user)
-                 (telega-chat-title chat-or-user)))
-         (image-properties
-          (list :scale 1.0
-                :width xw :height xh
-                :ascent 'center
-                :mask 'heuristic
-                ;; Correct text for tty-only avatar display
-                :telega-text (list (concat "(" (substring name 0 1) ")"
-                                           (make-string aw-chars-3 ?\u00A0))
-                                   (make-string (+ 3 aw-chars-3) ?\u00A0)))))
+                 (telega-chat-title chat-or-user))))
+    (if (telega-file-exists-p photofile)
+        (let ((img-type (image-type-from-file-name photofile))
+              (clip (telega-svg-clip-path svg "clip")))
+          (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
+          (svg-embed svg photofile
+                     (format "image/%S" img-type)
+                     nil
+                     :x (/ (- xw ch) 2) :y (/ margin 2)
+                     :width ch :height ch
+                     :clip-path "url(#clip)"))
 
-    (if (display-graphic-p)
-        (let ((svg (svg-create xw xh)))
-          (if (telega-file-exists-p photofile)
-              (let ((img-type (image-type-from-file-name photofile))
-                    (clip (telega-svg-clip-path svg "clip")))
-                (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
-                (svg-embed svg photofile
-                           (format "image/%S" img-type)
-                           nil
-                           :x (/ (- xw ch) 2) :y (/ margin 2)
-                           :width ch :height ch
-                           :clip-path "url(#clip)"))
+      ;; Draw initials
+      (let ((fsz (/ ch 2))
+            (color (if (eq (telega--tl-type chat-or-user) 'user)
+                       (telega-user-color chat-or-user)
+                     (telega-chat-color chat-or-user))))
+        (svg-gradient svg "cgrad" 'linear
+                      (list (cons 0 (cadr color)) (cons ch (caddr color))))
+        (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
+        (svg-text svg (substring name 0 1)
+                  :font-size (/ ch 2)
+                  :font-weight "bold"
+                  :fill "white"
+                  :font-family "monospace"
+                  ;; XXX insane X/Y calculation
+                  :x (- (/ xw 2) (/ fsz 3))
+                  :y (+ (/ fsz 3) (/ cfull 2)))))
 
-            ;; Draw initials
-            (let ((fsz (/ ch 2))
-                  (color (if (eq (telega--tl-type chat-or-user) 'user)
-                             (telega-user-color chat-or-user)
-                           (telega-chat-color chat-or-user))))
-              (svg-gradient svg "cgrad" 'linear
-                            (list (cons 0 (cadr color)) (cons ch (caddr color))))
-              (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
-              (svg-text svg (substring name 0 1)
-                        :font-size (/ ch 2)
-                        :font-weight "bold"
-                        :fill "white"
-                        :font-family "monospace"
-                        ;; XXX insane X/Y calculation
-                        :x (- (/ xw 2) (/ fsz 3))
-                        :y (+ (/ fsz 3) (/ cfull 2)))))
-          
-          (apply #'svg-image svg image-properties))
-      (cons 'dummy-image image-properties))))
+    (svg-image svg :scale 1.0
+               :width xw :height xh
+               :ascent 'center
+               :mask 'heuristic
+               ;; Correct text for tty-only avatar display
+               :telega-text (list (concat "(" (substring name 0 1) ")"
+                                          (make-string aw-chars-3 ?\u00A0))
+                                  (make-string (+ 3 aw-chars-3) ?\u00A0))
+               ))
+
+     (let* ((photofile (telega--tl-get file :local :path))
+           (cfactor (or (car telega-avatar-factors) 0.9))
+           (mfactor (or (cdr telega-avatar-factors) 0.1))
+           (xh (telega-chars-xheight 2))
+           (margin (* mfactor xh))
+           (ch (* cfactor xh))
+           (cfull (+ ch margin))
+           (aw-chars (telega-chars-in-width cfull))
+           (aw-chars-3 (if (> aw-chars 3) (- aw-chars 3) 0))
+           (xw (telega-chars-xwidth aw-chars))
+           (svg (svg-create xw xh))
+           (name (if (eq (telega--tl-type chat-or-user) 'user)
+                     (telega-user--name chat-or-user)
+                   (telega-chat-title chat-or-user))))
+      (if (telega-file-exists-p photofile)
+          (let ((img-type (image-type-from-file-name photofile))
+                (clip (telega-svg-clip-path svg "clip")))
+            (svg-circle clip (/ xw 2) (/ cfull 2) (/ ch 2))
+            (svg-embed svg photofile
+                       (format "image/%S" img-type)
+                       nil
+                       :x (/ (- xw ch) 2) :y (/ margin 2)
+                       :width ch :height ch
+                       :clip-path "url(#clip)"))
+
+        ;; Draw initials
+        (let ((fsz (/ ch 2))
+              (color (if (eq (telega--tl-type chat-or-user) 'user)
+                         (telega-user-color chat-or-user)
+                       (telega-chat-color chat-or-user))))
+          (svg-gradient svg "cgrad" 'linear
+                        (list (cons 0 (cadr color)) (cons ch (caddr color))))
+          (svg-circle svg (/ xw 2) (/ cfull 2) (/ ch 2) :gradient "cgrad")
+          (svg-text svg (substring name 0 1)
+                    :font-size (/ ch 2)
+                    :font-weight "bold"
+                    :fill "white"
+                    :font-family "monospace"
+                    ;; XXX insane X/Y calculation
+                    :x (- (/ xw 2) (/ fsz 3))
+                    :y (+ (/ fsz 3) (/ cfull 2)))))
+
+      (list 'dummy-image
+            :scale 1.0
+            :width xw :height xh
+            :ascent 'center
+            :mask 'heuristic
+            ;; Correct text for tty-only avatar display
+            :telega-text (list (concat "(" (substring name 0 1) ")"
+                                       (make-string aw-chars-3 ?\u00A0))
+                               (make-string (+ 3 aw-chars-3) ?\u00A0))))))
 
 (defun telega-symbol-emojify (emoji)
   "Attach `display' property with emoji svg to EMOJI string.

--- a/telega-media.el
+++ b/telega-media.el
@@ -558,7 +558,6 @@ File is specified with FILE-SPEC."
          (aw-chars (telega-chars-in-width cfull))
          (aw-chars-3 (if (> aw-chars 3) (- aw-chars 3) 0))
          (xw (telega-chars-xwidth aw-chars))
-         (svg (svg-create xw xh))
          (name (if (eq (telega--tl-type chat-or-user) 'user)
                    (telega-user--name chat-or-user)
                  (telega-chat-title chat-or-user)))
@@ -573,7 +572,7 @@ File is specified with FILE-SPEC."
                                    (make-string (+ 3 aw-chars-3) ?\u00A0)))))
 
     (if (display-graphic-p)
-        (progn
+        (let ((svg (svg-create xw xh)))
           (if (telega-file-exists-p photofile)
               (let ((img-type (image-type-from-file-name photofile))
                     (clip (telega-svg-clip-path svg "clip")))


### PR DESCRIPTION
Telega is barely usable in tty when emacs is bult `--without-librsvg`. The patch fixes this by wrapping all image-related functions in display-graphic-p checks.

Hopefully, imagemagick and librsvg won't be hard dependencies in the end but I'm not there yet. The proposed patches help a lot already, though.