### PR TITLE
Patch `ffplay` and `ffmpeg` paths instead of propagating ffmpeg input.

### DIFF
--- a/etc/guix.scm
+++ b/etc/guix.scm
@@ -89,10 +89,18 @@
 	       (("python3 run_tests.py")
 		""))
 	     #t))
-	 ;; Modify telega-util to reflect unique dir name in
-	 ;; `telega-install-data' phase.
-	 (add-after 'unpack 'telega-data-patch
-	   (lambda _
+	 (add-after 'unpack 'telega-paths-patch
+	   (lambda* (#:key inputs #:allow-other-keys)
+	     ;; Hard-code path to `ffplay`.
+	     (let ((ffplay-bin (string-append (assoc-ref inputs "ffmpeg")
+					      "/bin/ffplay")))
+	       (substitute* "telega-ffplay.el"
+		 (("\\(executable-find \"ffplay\"\\)")
+		  (string-append
+		   "(and (file-executable-p \"" ffplay-bin "\")"
+		   "\"" ffplay-bin "\")"))))
+	     ;; Modify telega-util to reflect unique dir name in
+	     ;; `telega-install-data' phase.
 	     (substitute* "telega-util.el"
 	       (("\\(concat \"etc/\" filename\\) telega--lib-directory")
 		"(concat \"telega-data/\" filename)
@@ -125,7 +133,6 @@
 	     (invoke "python3" "server/run_tests.py")
 	     #t))
 	 (delete 'configure)
-	 
 	 ;; Build emacs-side using `emacs-build-system'
 	 (add-after 'compress-documentation 'emacs-add-source-to-load-path
 	   (assoc-ref emacs:%standard-phases 'add-source-to-load-path))
@@ -144,9 +151,10 @@
 	   (assoc-ref emacs:%standard-phases 'build))
 	 (add-after 'emacs-build 'emacs-make-autoloads
 	   (assoc-ref emacs:%standard-phases 'make-autoloads)))))
+    (inputs
+     `(("ffmpeg" ,ffmpeg))) ; mp4/gif support.
     (propagated-inputs
      `(("emacs-visual-fill-column" ,emacs-visual-fill-column)
-       ("ffmpeg" ,ffmpeg) ; mp4/gif support.
        ("libwebp" ,libwebp))) ; sticker support.
     (native-inputs
      `(("tdlib" ,tdlib)

--- a/etc/guix.scm
+++ b/etc/guix.scm
@@ -91,14 +91,20 @@
 	     #t))
 	 (add-after 'unpack 'telega-paths-patch
 	   (lambda* (#:key inputs #:allow-other-keys)
-	     ;; Hard-code path to `ffplay`.
+	     ;; Hard-code paths to `ffplay` and `ffmpeg`.
 	     (let ((ffplay-bin (string-append (assoc-ref inputs "ffmpeg")
-					      "/bin/ffplay")))
+					      "/bin/ffplay"))
+		   (ffmpeg-bin (string-append (assoc-ref inputs "ffmpeg")
+					      "/bin/ffmpeg")))
 	       (substitute* "telega-ffplay.el"
 		 (("\\(executable-find \"ffplay\"\\)")
 		  (string-append
 		   "(and (file-executable-p \"" ffplay-bin "\")"
-		   "\"" ffplay-bin "\")"))))
+		   "\"" ffplay-bin "\")"))
+		 (("\\(executable-find \"ffmpeg\"\\)")
+		  (string-append
+		   "(and (file-executable-p \"" ffmpeg-bin "\")"
+		   "\"" ffmpeg-bin "\")"))))
 	     ;; Modify telega-util to reflect unique dir name in
 	     ;; `telega-install-data' phase.
 	     (substitute* "telega-util.el"


### PR DESCRIPTION
This is a revision to the previous pull request. This is a more hygienic way to ensure that ffmpeg functionality is given to emacs-telega on build-time.