### PR TITLE
Add video module to guix.scm

### DIFF
--- a/etc/guix.scm
+++ b/etc/guix.scm
@@ -30,6 +30,7 @@
 	     (gnu packages image)
 	     (gnu packages messaging)
 	     (gnu packages python)
+	     (gnu packages video)
 	     (guix build utils)
 	     (guix build-system gnu)
 	     (guix gexp)


### PR DESCRIPTION
Fixes

```
brettg@oryx ~/Repos/telega.el [env]$ bear guix build -f ./etc/guix.scm 
/home/brettg/Repos/telega.el/etc/guix.scm:149:5: In procedure inputs:
error: ffmpeg: unbound variable
hint: Did you forget `(use-modules (gnu packages video))'?
```