### PR TITLE
Revert change to error string for Emacs Lisp consistency

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -879,7 +879,7 @@ CHAT must be supergroup or channel."
       (setq order nil)
 
     (unless (numberp (read order))
-      (error "Error: Invalid order, must contain only digits.")))
+      (error "Invalid order, must contain only digits")))
 
   (setf (telega-chat-uaprop chat :order) order)
   (telega-chat--reorder chat nil)


### PR DESCRIPTION
Fixed #133 