### PR TITLE
Add emacs-company as an input to emacs-telega.

### DIFF
--- a/etc/guix.scm
+++ b/etc/guix.scm
@@ -152,6 +152,7 @@
      `(("ffmpeg" ,ffmpeg))) ; mp4/gif support.
     (propagated-inputs
      `(("emacs-visual-fill-column" ,emacs-visual-fill-column)
+       ("emacs-company" ,emacs-company)
        ("libwebp" ,libwebp))) ; sticker support.
     (native-inputs
      `(("tdlib" ,tdlib)


### PR DESCRIPTION
This will provide company-based completion support OOTB for users of Telega on GNU Guix, without having to install company themselves.