### PR TITLE
Add readme.md line for ldconfig cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ $ sudo make install
 It will install headers to `/usr/local/include` and library itself
 into `/usr/local/lib`.  These paths are hardcoded in `telega.el`.
 
+For Linux users, make sure `/usr/local/lib` is in you ldconfig cache, otherwise telega server build will fail.
+
 ### Building libtgvoip
 
 VoIP support in `telega.el` is optional, if you don't need VoIP, just


### PR DESCRIPTION
Hi

This is to add a line to readme.md to warn users to make sure ldconfig is setup correctly.

This pull request is to fix issue:

https://github.com/zevlg/telega.el/issues/168