### PR TITLE
server/Makefile: Build library rpath into server

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,22 +391,6 @@ exceptionally helpful.
 
 # FAQ
 
-**Q**: I have this error after `M-x telega RET`
-
-```console
-
-Status: telega-server: exited abnormally with code 127
-/home/user/.telega/telega-server: error while loading shared libraries:
-libtdjson.so: cannot open shared object file: No such file or directory
-```
-
-**A**: Add `/usr/local/lib` into library loading path using next:
-
-```console
-# echo "/usr/local/lib" > /etc/ld.so.conf.d/usr_local_lib.conf
-# ldconfig
-```
-
 **Q**: I have this error while installing telega
 
 ```console

--- a/server/Makefile
+++ b/server/Makefile
@@ -5,7 +5,7 @@ LIBS_PREFIX=/usr/local
 endif
 
 CFLAGS=-I$(LIBS_PREFIX)/include -Wall -g -pthread
-LDFLAGS=-L$(LIBS_PREFIX)/lib -ltdjson
+LDFLAGS=-L$(LIBS_PREFIX)/lib -Wl,-rpath,$(LIBS_PREFIX)/lib -ltdjson
 
 PROG=telega-server
 SOURCES=telega-server.c telega-dat.c telega-pngext.c


### PR DESCRIPTION
Builds the rpath for the Telegram library into the `telega-server`
binary so that it will be found automatically when starting
`telega-server`, regardless of where `LIBS_PREFIX` is pointing.