### PR TITLE
fix build on non-GNU systems

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -30,8 +30,8 @@ $(PROG): $(SOURCES)
 	$(CC) $(CFLAGS) -o $(PROG) $(SOURCES) $(LDFLAGS)
 
 install: $(PROG)
-	@install -v -d $(INSTALL_PREFIX)
-	@install -v $(PROG) $(INSTALL_PREFIX)
+	@install -d $(INSTALL_PREFIX)
+	@install $(PROG) $(INSTALL_PREFIX)
 
 test:
 	@python3 run_tests.py

--- a/telega-server.el
+++ b/telega-server.el
@@ -128,7 +128,9 @@ Otherwise query user about building flags."
                )))
       (unless (zerop
                (shell-command
-                (concat "make " build-flags " "
+                (concat (or (executable-find "gmake")
+                            "make")
+                        " " build-flags " "
                         "LIBS_PREFIX=" (expand-file-name telega-server-libs-prefix) " "
                         "INSTALL_PREFIX=" (expand-file-name telega-directory) " "
                         "server-reinstall")))


### PR DESCRIPTION
First of all, thanks for developing this. I cannot convey in words how happy I am to have a working telegram client on my OpenBSD desktop (telegram web does not count), and it's even within emacs!  You really made my day.

Talking about this proposal: from #199 I can see that some changes to the build system are planned after td 1.7 (I don't know when it's scheduled), so I tried to minimize the changes.  I'm making the path to make customizable, so one can (setq telega-make-command "gmake") before (telega-build-server).  The root Makefile already uses $(MAKE), so this setting is propagated when building the server.

Another possibility could be to change telega-build-server so it let the user change the command to execute when called with a prefix argument.  Now that I'm thinking of it, it's probably better than adding a global variable that can go away soon.

I'm also dropping the -v flag to install(1) as it's non standard and not supported by at least Open and FreeBSD install.

P.S.: apart from this issues with gmake and install, everything else (including photos, notifications, stickers, audio, ...) is working flawlessly!