### PR TITLE
key binding 'k' conflict with vim's cursor move up key 'k'

### DIFF
--- a/telega-msg.el
+++ b/telega-msg.el
@@ -69,7 +69,7 @@
     (define-key map (kbd "e") 'telega-msg-edit)
     (define-key map (kbd "f") 'telega-msg-forward-marked-or-at-point)
     (define-key map (kbd "d") 'telega-msg-delete-marked-or-at-point)
-    (define-key map (kbd "k") 'telega-msg-delete-marked-or-at-point)
+    ;; (define-key map (kbd "k") 'telega-msg-delete-marked-or-at-point)
     (define-key map (kbd "l") 'telega-msg-redisplay)
     (define-key map (kbd "=") 'telega-msg-diff-edits)
     (define-key map (kbd "R") 'telega-msg-resend)


### PR DESCRIPTION
I am vim user . So I use evil mode to use emacs.

vim move cursor by hjkl.  telega keybinding k conflict with vim.

`telega-msg-delete-marked-or-at-point` bind three keys :  k, d, DEL. so I think,  remove k, there will be no impact on the overall situation.
```
(define-key map (kbd "DEL") 'telega-msg-delete-marked-or-at-point)
(define-key map (kbd "d") 'telega-msg-delete-marked-or-at-point)
(define-key map (kbd "k") 'telega-msg-delete-marked-or-at-point)
```