### PR TITLE
Use telega-username as the face of tracking mode-line notifications

### DIFF
--- a/telega-customize.el
+++ b/telega-customize.el
@@ -144,7 +144,9 @@ where PROXY-TYPE is one of:
 (defcustom telega-use-tracking-for nil
   "*Specifies Chat Filter for chats to be tracked with tracking.el.
 Make sure you have tracking.el loaded if this option is used.
-Only chats with corresponding opened chatbuf are tracked."
+Only chats with corresponding opened chatbuf are tracked.
+Tracking notifications for telega buffers will use the
+`telega-tracking` face."
   :package-version '(telega . "0.5.7")
   :type 'list
   :options '((not (or saved-messages (type channel bot)))
@@ -1638,6 +1640,11 @@ Install all symbol widths inside `telega-load-hook'."
      :foreground "RoyalBlue")
     (t :bold t))
   "Face to display username for chats/users."
+  :group 'telega-faces)
+
+(defface telega-tracking
+  '((t :inherit telega-username))
+  "Face to display tracking mode-line notifications."
   :group 'telega-faces)
 
 (defface telega-entity-type-mention

--- a/telega-tdlib-events.el
+++ b/telega-tdlib-events.el
@@ -478,7 +478,7 @@ NOTE: we store the number as custom chat property, to use it later."
                       telega-chatbuf--chat telega-use-tracking-for)
                      (not (plist-get new-msg :is_outgoing))
                      (not (telega-msg-seen-p new-msg telega-chatbuf--chat)))
-            (tracking-add-buffer (current-buffer)))
+            (tracking-add-buffer (current-buffer) '(telega-tracking)))
 
           ;; If message is visibible in some window, then mark it as read
           ;; see https://github.com/zevlg/telega.el/issues/4


### PR DESCRIPTION
When adding a buffer for notifications with the tracking package, one can specify a list of faces to use for it in the modeline.  This is useful not only for appearance, but also because the face can be used to prioritize the notification, altering the order in which it is shown (via tracking-faces-priorities).  I think telega-username is a good candidate for this, at least as a default.