### PR TITLE
fix nativecomp emacs cannot be used normally

### DIFF
--- a/telega-sort.el
+++ b/telega-sort.el
@@ -27,6 +27,8 @@
 ;; directly into ~telega-sort-criteria-alist~, use
 ;; ~define-telega-sorter~ instead.
 
+(require 'telega-core)
+
 
 (declare-function telega-chat--update "telega-tdlib-events" (chat &rest events))
 

--- a/telega-util.el
+++ b/telega-util.el
@@ -37,6 +37,7 @@
 (require 'org)                          ; `org-read-date'
 (require 'rainbow-identifiers)
 
+(require 'telega-core)
 (require 'telega-customize)
 
 (declare-function telega-root--buffer "telega-root")


### PR DESCRIPTION
nativecomp produces the following error
`
error in process filter: telega-emoji-create-svg: Invalid function: telega-svg-create
error in process filter: Invalid function: telega-svg-create
Error running timer ‘telega-server--idle-timer-function’: (invalid-function telega-ins-fmt)
`