### PR TITLE
Small addition to docs

### DIFF
--- a/docs/telega-ellit.org
+++ b/docs/telega-ellit.org
@@ -828,6 +828,4 @@ project.
 * Troubleshooting
 ** Warning for TDLib version below minimum required, even though correct version is installed
 If at starting telega you get the warning =TDLib version=%s < %s (min required),please upgrade TDLib and recompile `telega-server= even though your tdlib version is satisfying telega's requirements, be aware that deleting the telega package and reinstalling it via melpa will not recompile the server, run =telega-server-build= instead.
-
 #  LocalWords:  customizable chatbuf tdlib gmake
-

--- a/docs/telega-ellit.org
+++ b/docs/telega-ellit.org
@@ -825,4 +825,9 @@ project.
 
 #+ELLIT-INCLUDE: ../contrib/telega-mnz.el
 
+* Troubleshooting
+** Warning for TDLib version below minimum required, even though correct version is installed
+If at starting telega you get the warning =TDLib version=%s < %s (min required),please upgrade TDLib and recompile `telega-server= even though your tdlib version is satisfying telega's requirements, be aware that deleting the telega package and reinstalling it via melpa will not recompile the server, run =telega-server-build= instead.
+
 #  LocalWords:  customizable chatbuf tdlib gmake
+


### PR DESCRIPTION
I added a small section to the docs that covers a problem I ran into. 
Basically I did not realize that re-installing telega via Melpa  would not rebuild the server so I received the minimum TDLib version warning even though the correct version was installed.