### PR TITLE
Rename the function telega-chatbuf-attach-member to something more intuitive.

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -3403,7 +3403,7 @@ Uses `telega-screenshot-function' to take a screenshot."
         (x-focus-frame (window-frame (get-buffer-window)))
         (telega-chatbuf--attach-tmp-photo tmpfile)))))
 
-(defun telega-chatbuf-attach-member (user)
+(defun telega-chatbuf-add-member (user)
   "Add USER to the chat members."
   (interactive (list (telega-completing-read-user "Add member: ")))
   (cl-assert user)

--- a/telega-chat.el
+++ b/telega-chat.el
@@ -3403,12 +3403,6 @@ Uses `telega-screenshot-function' to take a screenshot."
         (x-focus-frame (window-frame (get-buffer-window)))
         (telega-chatbuf--attach-tmp-photo tmpfile)))))
 
-(defun telega-chatbuf-add-member (user)
-  "Add USER to the chat members."
-  (interactive (list (telega-completing-read-user "Add member: ")))
-  (cl-assert user)
-  (telega-chat-add-member telega-chatbuf--chat user))
-
 (defun telega-chatbuf-sticker-insert (sticker)
   "Attach STICKER to the input."
   (let ((thumb (plist-get sticker :thumbnail))

--- a/telega-customize.el
+++ b/telega-customize.el
@@ -978,7 +978,7 @@ different days. Such as:
               (not (telega-chat-private-p telega-chatbuf--chat)))
      telega-chatbuf-attach-poll)
     ("contact" nil telega-chatbuf-attach-contact)
-    ("member" nil telega-chatbuf-attach-member)
+    ("new-member" nil telega-chatbuf-add-member)
     ("sticker" nil telega-chatbuf-attach-sticker)
     ("animation" nil telega-chatbuf-attach-animation)
     ("dice" nil telega-chatbuf-attach-dice)

--- a/telega-customize.el
+++ b/telega-customize.el
@@ -978,7 +978,6 @@ different days. Such as:
               (not (telega-chat-private-p telega-chatbuf--chat)))
      telega-chatbuf-attach-poll)
     ("contact" nil telega-chatbuf-attach-contact)
-    ("new-member" nil telega-chatbuf-add-member)
     ("sticker" nil telega-chatbuf-attach-sticker)
     ("animation" nil telega-chatbuf-attach-animation)
     ("dice" nil telega-chatbuf-attach-dice)


### PR DESCRIPTION
While "attach-member" might be consistent with the other "attach-*" functions, given the nature of the command and the consequences of misuse as well as the lack of confirmation it is important to make it clear that this adds a NEW member rather than mentioning someone who is already a member. 