### PR TITLE
Make native-comp happy

### DIFF
--- a/telega-modes.el
+++ b/telega-modes.el
@@ -29,6 +29,7 @@
 (require 'telega-server)
 (require 'telega-filter)
 (require 'telega-util)
+(eval-when-compile (require 'dom))
 
 (defvar tracking-buffers)
 

--- a/telega-sticker.el
+++ b/telega-sticker.el
@@ -30,6 +30,7 @@
 (require 'telega-tdlib)
 (require 'telega-util)
 (require 'telega-media)
+(eval-when-compile (require 'dom))
 
 ;; shutup compiler
 (defvar ido-matches)


### PR DESCRIPTION
When using native-comp branch of Emacs, elisp codes are compiled to native code. Some macros used in telega were not correctly required at compile time, causing errors like the following for some users:
```
---[telega bug]
PP-ERROR: (telega-root--chat-known-pp OMITTED_FOR_PRIVACY
) ==>
(invalid-function dom-attr)
------
```
