### PR TITLE
Reuse crop filter from video cmd for preview

### DIFF
--- a/telega-vvnote.el
+++ b/telega-vvnote.el
@@ -436,10 +436,15 @@ Return filename with recorded video note."
         (list :start-point (copy-marker (point))))
   (let* ((telega-vvnote--record-progress 0)
          (note-file (telega-temp-name "video-note" ".mp4"))
+         (crop-filter
+          (if (string-match "\\(crop=.*?\\)\s" telega-vvnote-video-cmd)
+              (match-string 1 telega-vvnote-video-cmd)
+            ;; default crop
+            "crop=240:240:40:0"))
          (ffmpeg-args
           (nconc (cdr (split-string telega-vvnote-video-cmd " " t))
                  (list note-file
-                       "-f" "image2pipe" "-vf" "crop=240:240:40:0"
+                       "-f" "image2pipe" "-vf" crop-filter
                        "-vcodec" "png" "-")))
          (capture-proc (telega-ffplay-to-png nil ffmpeg-args
                          #'telega-vvnote-video--record-callback))


### PR DESCRIPTION
On both Linux and macOS minimum video sizes ffmpeg can capture are
larger then video note size, required by telegram. Telega therefore
has to use crop to prepare video. `telega-vvnote-video-cmd` sets crop
dimensions for both Linux and macOS, however they might not be ideal,
especially on macOS, where size of video captured is about 2-3 times
larger then video note size.

Users can customize `telega-vvnote-video-cmd`, but the preview filter
pipeline is hardcoded. Let's change that and let's extract crop filter
parameters from `telega-vvnote-video-cmd`, preserving status quo
behaviour when it's impossible.

starting # with '#' will be ignored, and an empty message aborts the
commit.  # # On branch master # Your branch is up to date with
'origin/master'.  # # Changes to be committed: # modified:
telega-vvnote.el #