### PR TITLE
Prefer telega-server binary from absolute path

### DIFF
--- a/telega-server.el
+++ b/telega-server.el
@@ -143,10 +143,11 @@ Otherwise query user about building flags."
   "Find telega-server executable.
 Raise error if not found."
   (let ((exec-path (cons telega-directory exec-path)))
-    (or (executable-find "telega-server")
-        (progn (telega-server-build)
-               (executable-find "telega-server"))
-        (error "`telega-server' not found in exec-path"))))
+    (or (if (file-executable-p telega-server-command) telega-server-command nil)
+        (or (executable-find "telega-server")
+            (progn (telega-server-build)
+                   (executable-find "telega-server"))
+            (error "`telega-server' not found in exec-path")))))
 
 (defun telega-server-version ()
   "Return telega-server version."


### PR DESCRIPTION
In nixpkgs we patch `telega-server-command` to point to an absolute store path ( https://github.com/NixOS/nixpkgs/blob/c6f1dc2320db5b28136ca4a78ffce5cf0b7cdba5/pkgs/applications/editors/emacs-modes/melpa-packages.nix#L303-L305 ).

`telega-server--find-bin` does not take the absolute path case into account but fails because the binary cannot be found in `exec-path`.

cc @zevlg 