### PR TITLE
Use canonical test for within a minibuffer

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -2319,7 +2319,7 @@ If message thread filtering is enabled, use it first."
 
 (defun telega-chatbuf--minibuf-post-command ()
   "Function to search chatbuf history input."
-  (cl-assert (eq major-mode 'minibuffer-inactive-mode))
+  (cl-assert (minibufferp))
   (let ((regexp (buffer-substring (minibuffer-prompt-end) (point))))
     (if (string-empty-p regexp)
         (with-telega-chatbuf telega-minibuffer--chat
@@ -2334,7 +2334,7 @@ If message thread filtering is enabled, use it first."
 (defun telega-chatbuf--input-search-prev (&optional forward-p)
   "For `C-r' in minibuffer."
   (interactive)
-  (cl-assert (eq major-mode 'minibuffer-inactive-mode))
+  (cl-assert (minibufferp))
   (let ((regexp telega-minibuffer--string))
     (with-telega-chatbuf telega-minibuffer--chat
       (telega-chatbuf-input-match regexp forward-p))))
@@ -2347,19 +2347,19 @@ If message thread filtering is enabled, use it first."
 (defun telega-chatbuf--input-search-cancel ()
   "Cancel input search results."
   (interactive)
-  (cl-assert (eq major-mode 'minibuffer-inactive-mode))
+  (cl-assert (minibufferp))
   (delete-region (minibuffer-prompt-end) (point))
   (exit-minibuffer))
 
 (defun telega-chatbuf--input-search-accept ()
   "Accept input search results."
   (interactive)
-  (cl-assert (eq major-mode 'minibuffer-inactive-mode))
+  (cl-assert (minibufferp))
   (exit-minibuffer))
 
 (defun telega-chatbuf--input-search-input-prev (&optional forward-p)
   (interactive)
-  (cl-assert (eq major-mode 'minibuffer-inactive-mode))
+  (cl-assert (minibufferp))
   (delete-region (minibuffer-prompt-end) (point))
 
   (let ((prompt-input (with-telega-chatbuf telega-minibuffer--chat


### PR DESCRIPTION
The canonical way to test wihin a minibuffer is via `minibufferp`. The
old way of `(eq major-mode 'minibuffer-inactive-mode)` will no longer
work after 55db25b257 in Emacs master branch (see Emacs bug 47150 for
details). This commit fixes an old bug related to the implementation of
when is the minibuffer in minibuffer-inactive-mode. After the commit, we
have minibuffer-mode and minibuffer-inactive-mode.