### PR TITLE
Remove `cl--plist-remove' usage in telega stable branch

### DIFF
--- a/telega-util.el
+++ b/telega-util.el
@@ -57,9 +57,17 @@ Also return `nil' if FILENAME is `nil'."
        (not (string-empty-p filename))
        (file-exists-p filename)))
 
-(defsubst telega-plist-del (plist prop)
+(defun telega-plist-del (plist prop)
   "From PLIST remove property PROP."
-  (cl--plist-remove plist (plist-member plist prop)))
+  ;; NOTE: `cl--plist-remove' has been removed in Emacs master
+  ;; See https://t.me/emacs_telega/27687
+  ;; Code taken from `org-plist-delete'
+  (let (p)
+    (while plist
+      (if (not (eq prop (car plist)))
+          (setq p (plist-put p (car plist) (nth 1 plist))))
+      (setq plist (cddr plist)))
+    p))
 
 (defun telega-plist-map (func plist)
   "Map FUNCTION on PLIST and return resulting list.
@@ -930,7 +938,7 @@ SORT-CRITERIA is a chat sort criteria to apply. (NOT YET)"
                          (telega-sort-chats
                           (or sort-criteria telega-chat-completing-sort-criteria)
                           (telega-filter-chats (or chats telega--ordered-chats)
-                                               '(or main archive))))))
+                                               '(or main archive has-chatbuf))))))
     (car (alist-get (funcall telega-completing-read-function
                              prompt choices nil t)
                     choices nil nil 'string=))))

--- a/telega-util.el
+++ b/telega-util.el
@@ -938,7 +938,7 @@ SORT-CRITERIA is a chat sort criteria to apply. (NOT YET)"
                          (telega-sort-chats
                           (or sort-criteria telega-chat-completing-sort-criteria)
                           (telega-filter-chats (or chats telega--ordered-chats)
-                                               '(or main archive has-chatbuf))))))
+                                               '(or main archive))))))
     (car (alist-get (funcall telega-completing-read-function
                              prompt choices nil t)
                     choices nil nil 'string=))))

--- a/test.el
+++ b/test.el
@@ -209,6 +209,17 @@ Have Stoploss 690 Satoshi." :entities []))))
                  '(:@type "formattedText" :text "prefix bold here code trailing" :entities [(:@type "textEntity" :offset 7 :length 4 :type (:@type "textEntityTypeBold")) (:@type "textEntity" :offset 17 :length 4 :type (:@type "textEntityTypeCode"))])))
   )
 
+
+(ert-deftest telega-plist-del-test ()
+  "Testing for `telega-plist-del'."
+  (should (equal '(:test 1)
+                 (telega-plist-del '(:hahah 2 :test 1) :hahah)))
+  (should (equal '(:not-deleted 2)
+                 (telega-plist-del '(:not-deleted 2) :not-deletedXX)))
+  (should (equal nil
+                 (telega-plist-del '(:delete-me 1) :delete-me)))
+  )
+
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:


### PR DESCRIPTION
Basically a backport of [this](https://github.com/zevlg/telega.el/commit/5e20c82918219cfc8555d17ebc6818c1d79fa62c) commit into `releases` branch.
