### PR TITLE
[fix] `custom-declare-variable' wants a form rather than a value

### DIFF
--- a/telega-customize.el
+++ b/telega-customize.el
@@ -1196,7 +1196,7 @@ COMMAND-FUNC - Command function to execute."
 
 (custom-declare-variable
  'telega-dired-dwim-target
- dired-dwim-target
+ 'dired-dwim-target
  "*Value to bind `dired-dwim-target' to, in telega file pickers."
  :type (custom-variable-type 'dired-dwim-target)
  :group 'telega-chat)


### PR DESCRIPTION
It's even highlighted in the docstring of `custom-declare-variable` but I missed it:

> DEFAULT should be an expression to evaluate to compute the default value,
> not the default value itself.