### PR TITLE
[add] Dynamic check of supported audio inputs

### DIFF
--- a/telega-ffplay.el
+++ b/telega-ffplay.el
@@ -27,22 +27,35 @@
 (require 'cl-lib)
 (require 'telega-core)
 
+(defun telega-ffplay--parse-ffmpeg-output (option support &rest desired-properties)
+  "Parsing the ffmpeg output for the OPTION for the DESIRED-PROPERTIES.
+SUPPORT should be a list of states supported by the DESIRED-PROPERTIES.
+Currently it may contain a decoder, an encoder, or both."
+  (let* ((output (shell-command-to-string (concat "ffmpeg -v quiet -" option)))
+         (header-end (string-match-p "-" output))
+         (additional-characters
+          (- (string-match-p
+              "="
+              (string-trim
+               (cadr (split-string (substring output 0 header-end) "\n"))))
+             2)))
+    (cl-remove-if-not
+     #'stringp
+     (mapcar (lambda (prop)
+               (when (string-match-p
+                      (concat (concat (if (memq 'decoder support) "D" ".")
+                                      (if (memq 'encoder support) "E" "."))
+                              (when (> additional-characters 0)
+                                (make-string additional-characters ?\.))
+                              prop)
+                      output)
+                 prop))
+             desired-properties))))
+
 (defun telega-ffplay-check-codecs (how &rest codecs)
   "Check CODEC is available in ffmpeg.
 Return list of available codecs."
-  (let ((codecs-output
-         (shell-command-to-string "ffmpeg -v quiet -codecs")))
-    (cl-remove-if-not
-     #'stringp
-     (mapcar (lambda (codec)
-               (when (string-match-p
-                      (concat (concat (if (memq 'decoder how) "D" ".")
-                                      (if (memq 'encoder how) "E" "."))
-                              "....."
-                              codec)
-                      codecs-output)
-                 codec))
-             codecs))))
+  (apply #'telega-ffplay--parse-ffmpeg-output "codecs" how codecs))
 
 (defconst telega-ffplay--has-encoders
   (telega-ffplay-check-codecs '(encoder) "opus" "hevc" "aac" "h264"))

--- a/telega-ffplay.el
+++ b/telega-ffplay.el
@@ -27,11 +27,11 @@
 (require 'cl-lib)
 (require 'telega-core)
 
-(defun telega-ffplay--parse-ffmpeg-output (option support &rest desired-properties)
-  "Parsing the ffmpeg output for the OPTION for the DESIRED-PROPERTIES.
+(defun telega-ffplay--check-ffmpeg-output (option support &rest desired-properties)
+  "Check the ffmpeg output for the OPTION for the DESIRED-PROPERTIES.
 SUPPORT should be a list of states supported by the DESIRED-PROPERTIES.
 Currently it may contain a decoder, an encoder, or both."
-  (let* ((output (shell-command-to-string (concat "ffmpeg -v quiet -" option)))
+  (let* ((output (shell-command-to-string (concat "ffmpeg -v quiet " option)))
          (header-end (string-match-p "-" output))
          (additional-characters
           (- (string-match-p
@@ -45,8 +45,8 @@ Currently it may contain a decoder, an encoder, or both."
                (when (string-match-p
                       (concat (concat (if (memq 'decoder support) "D" ".")
                                       (if (memq 'encoder support) "E" "."))
-                              (when (> additional-characters 0)
-                                (make-string additional-characters ?\.))
+                              (cl-assert (>= additional-characters 0))
+                              (make-string additional-characters ?\.)
                               prop)
                       output)
                  prop))
@@ -55,7 +55,7 @@ Currently it may contain a decoder, an encoder, or both."
 (defun telega-ffplay-check-codecs (how &rest codecs)
   "Check CODEC is available in ffmpeg.
 Return list of available codecs."
-  (apply #'telega-ffplay--parse-ffmpeg-output "codecs" how codecs))
+  (apply #'telega-ffplay--check-ffmpeg-output "-codecs" how codecs))
 
 (defconst telega-ffplay--has-encoders
   (telega-ffplay-check-codecs '(encoder) "opus" "hevc" "aac" "h264"))

--- a/telega-msg.el
+++ b/telega-msg.el
@@ -724,7 +724,8 @@ non-nil."
                             (unless (equal telega-vvnote-play-speed 1)
                               (format " -af atempo=%.2f"
                                       telega-vvnote-play-speed))
-                            " -f alsa default -vsync 0")
+                            (concat " -f " (car telega-vvnote--has-audio-inputs))
+                            " default -vsync 0")
                          (list #'telega-msg-video-note--ffplay-callback msg)
                          :seek paused-p :speed telega-vvnote-play-speed))
             (with-telega-chatbuf (telega-msg-chat msg)

--- a/telega-vvnote.el
+++ b/telega-vvnote.el
@@ -51,11 +51,20 @@
   :type 'boolean
   :group 'telega-vvnote)
 
+(defun telega-vvnote-check-devices (how &rest devices)
+  "Check DEVICES is available in ffmpeg.
+Return list of available DEVICES."
+  (apply #'telega-ffplay--parse-ffmpeg-output "devices" how devices))
+
+(defconst telega-vvnote--has-audio-inputs
+  (telega-vvnote-check-devices '(encoder) "alsa" "pulse"))
+
 (defcustom telega-vvnote-voice-record-args
   (concat (if (eq system-type 'darwin)
               "-f avfoundation -i :default"
             ;; gnu/linux
-            "-f alsa -i default")
+            (concat "-f " (car telega-vvnote--has-audio-inputs)
+                    " -i default"))
           (cond ((member "opus1" telega-ffplay--has-encoders)
                  ;; Try OPUS if available, results in 3 times smaller
                  ;; files then AAC version with same sound quality
@@ -73,7 +82,8 @@
   (concat (if (eq system-type 'darwin)
               "-f avfoundation -s 640x480 -framerate 30 -i default -r 30 -f avfoundation -i :default"
             ;; gnu/linux
-            "-f v4l2 -s 320x240 -i /dev/video0 -r 30 -f alsa -i default")
+            (concat "-f v4l2 -s 320x240 -i /dev/video0 -r 30 -f "
+                    (car telega-vvnote--has-audio-inputs) " -i default"))
           " -vf format=yuv420p,scale=320:240,crop=240:240:40:0"
           " -vcodec " (if (member "hevc" telega-ffplay--has-encoders)
                           "hevc"

--- a/telega-vvnote.el
+++ b/telega-vvnote.el
@@ -54,7 +54,7 @@
 (defun telega-vvnote-check-devices (how &rest devices)
   "Check DEVICES is available in ffmpeg.
 Return list of available DEVICES."
-  (apply #'telega-ffplay--parse-ffmpeg-output "devices" how devices))
+  (apply #'telega-ffplay--check-ffmpeg-output "-devices" how devices))
 
 (defconst telega-vvnote--has-audio-inputs
   (telega-vvnote-check-devices '(encoder) "alsa" "pulse"))
@@ -82,8 +82,8 @@ Return list of available DEVICES."
   (concat (if (eq system-type 'darwin)
               "-f avfoundation -s 640x480 -framerate 30 -i default -r 30 -f avfoundation -i :default"
             ;; gnu/linux
-            (concat "-f v4l2 -s 320x240 -i /dev/video0 -r 30 -f "
-                    (car telega-vvnote--has-audio-inputs) " -i default"))
+            (concat "-f v4l2 -s 320x240 -i /dev/video0 -r 30 "
+                    "-f " (car telega-vvnote--has-audio-inputs) " -i default"))
           " -vf format=yuv420p,scale=320:240,crop=240:240:40:0"
           " -vcodec " (if (member "hevc" telega-ffplay--has-encoders)
                           "hevc"


### PR DESCRIPTION
telega-vvnote-voice-record-args, telega-vvnote-video-record-args
telega-msg-open-video-note use introdused telega-vvnote--has-audio-inputs
to dynamicaly check the supported audio inputs.