### PR TITLE
Support wrap backwards from end of buffer

### DIFF
--- a/telega-root.el
+++ b/telega-root.el
@@ -871,8 +871,9 @@ If corresponding chat node does not exists in EWOC, then create new one."
               (telega-chat-match-p chat chat-filter)))
           'no-error)
          (when wrap
-           ;; Wrap from the beginning
-           (goto-char (point-min))
+           ;; Wrap from the beginning, or backwards from the end of buffer 
+           ;; if n is negative
+           (goto-char (if (> n 0) (point-min) (point-max)))
            (telega-button-forward
                (or n 1)
              (lambda (button)


### PR DESCRIPTION
Original func fails to wrap backwards from the end of buffer 
while n is negative. 

Paving infrastructure for the implementation of following commands:

```
(defun telega-root-prev-unread ()
    "Move point to the previous chat with unread message."
    (interactive)
    (telega-root-next-unread -1))

(defun telega-root-prev-important()
    "Move point to the previous important chat."
    (interactive)
    (telega-root-next-important -1))

(defun telega-root-prev-mention()
    "Move point to the previous chat with mention."
    (interactive)
    (telega-root-next-mention -1))

(defun telega-root-prev-reaction ()
    "Move point to the previous chat with unread reaction."
    (interactive)
    (telega-root-next-reaction -1))
```