### PR TITLE
Correct a trivial event message misspelling

### DIFF
--- a/telega-tdlib-events.el
+++ b/telega-tdlib-events.el
@@ -897,7 +897,7 @@ messages."
       (callStateDiscarded
        (let ((discad (plist-get state :reason))
              (user (telega-user-get (plist-get call :user_id))))
-         (message "Call %s discaded: %s" (telega-user--name user)
+         (message "Call %s discarded: %s" (telega-user--name user)
                   (substring (plist-get discad :@type) 17))))
       )
 

--- a/telega-tdlib-events.el
+++ b/telega-tdlib-events.el
@@ -895,10 +895,10 @@ messages."
                   (telega-user--name user) (plist-get err :message))))
 
       (callStateDiscarded
-       (let ((discad (plist-get state :reason))
+       (let ((discard (plist-get state :reason))
              (user (telega-user-get (plist-get call :user_id))))
          (message "Call %s discarded: %s" (telega-user--name user)
-                  (substring (plist-get discad :@type) 17))))
+                  (substring (plist-get discard :@type) 17))))
       )
 
     ;; Delete call from the list, if call is ended


### PR DESCRIPTION
I changed "discaded" to "discarded" in the telega--on-updateCall function (telega-tdlib-events.el)