### PR TITLE
Add support for libayatana-appindicator library to telega-server

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -18,6 +18,12 @@ CFLAGS+=-DWITH_APPINDICATOR
 CFLAGS+=`pkg-config --cflags appindicator3-0.1`
 LDFLAGS+=`pkg-config --libs appindicator3-0.1`
 SOURCES+=telega-appindicator.c
+else ifeq ($(shell pkg-config --exists ayatana-appindicator3-0.1 && echo yes), yes)
+CFLAGS+=-DWITH_APPINDICATOR
+CFLAGS+=-DWITH_AYATANA_APPINDICATOR
+CFLAGS+=`pkg-config --cflags ayatana-appindicator3-0.1`
+LDFLAGS+=`pkg-config --libs ayatana-appindicator3-0.1`
+SOURCES+=telega-appindicator.c
 endif
 
 ifdef WITH_VOIP

--- a/server/telega-appindicator.c
+++ b/server/telega-appindicator.c
@@ -34,7 +34,11 @@
 #include <stdbool.h>
 #include <assert.h>
 
+#ifdef WITH_AYATANA_APPINDICATOR
+#include <libayatana-appindicator/app-indicator.h>
+#else
 #include <libappindicator/app-indicator.h>
+#endif
 
 extern void telega_output_json(const char* otype, const char* json);
 

--- a/telega-modes.el
+++ b/telega-modes.el
@@ -252,7 +252,8 @@ If MESSAGES-P is non-nil then use number of messages with mentions."
 ;; Global minor mode to display =telega= status in system tray.  This
 ;; mode requires appindicator support in the =telega-server=.  To add
 ;; appindicator support to =telega-server=, please install
-;; =libappindicator3-dev= system package and rebuild =telega-server=
+;; =libappindicator3-dev= or =libayatana-appindicator3-dev=
+;; system package and rebuild =telega-server=
 ;; with {{{kbd(M-x telega-server-build RET}}}.
 ;;
 ;; Screenshot of system tray with enabled =telega= appindicator:


### PR DESCRIPTION
Ubuntu 22 drops support of the `libappindicator` library in prior to `libayatana-appindicator`. It still has `libappindicator` in it's repo, but `ubuntu-desktop` package depends on ayatana version, so user can't just install `libappindicator`. You can check some background here - https://github.com/AyatanaIndicators/libayatana-appindicator/issues/30#issuecomment-950224779. 

Luckily, `libayatana-appindicator` interface is identical to `libappindicator`, so I added some additional ifs to use any of those libraries with `telega-appindicator`.
