### PR TITLE
[telega-bridge-bot] fix: Update telega-user-title function usage.

### DIFF
--- a/contrib/telega-bridge-bot.el
+++ b/contrib/telega-bridge-bot.el
@@ -502,8 +502,9 @@ ARGS is the arguments passed the the FUN."
     (if-let* ((modified? (plist-get msg :telega-bridge-bot-modified))
               (sender (telega-msg-sender msg))
               (sender-name
-               (when (telega-user-p sender)
-                 (telega-user-title sender 'full-name-and-username))))
+               (concat
+                (telega-user-title sender 'full-name) " "
+                (telega-user-title sender 'username))))
         ;; if msg sender is a bridge bot then we want to display
         ;; the user title and the username in one line message
         (cl-letf (((symbol-function 'telega-msg-sender-username)


### PR DESCRIPTION
The `telega-user-title` function has modified in recent updates, so we also need update here.

Here we display both full_name and bot username like "Forward: Hello alice@matrix_bot",