### PR TITLE
telega-ins: correctly display last-seen time in the past

### DIFF
--- a/telega-ins.el
+++ b/telega-ins.el
@@ -355,7 +355,7 @@ Format is:
               ;; I18N: lng_status_lastseen_now
               "last seen just now")
              ((< online-dur (* 3 24 60 60))
-              (format "last seen in %s"
+              (format "last seen %s ago"
                       (telega-duration-human-readable online-dur 1)))
              ((eq status 'userStatusRecently)
               ;; I18N: lng_status_recently


### PR DESCRIPTION
In English, the phrase "last seen *in* $time" is referring to a time in the future (буквально, "в последний раз видели *через* $время").

To refer to a time in the past, the construct "last seen $time *ago*" ("видели $время *назад*") must be used.

This fixes #428.