### PR TITLE
telega-ins: be resilient to missing story/story sender not defined when inserting a webpage

### DIFF
--- a/telega-ins.el
+++ b/telega-ins.el
@@ -1021,8 +1021,8 @@ Return `non-nil' if WEB-PAGE has been inserted."
               ((plist-get web-page :voice_note)
                (telega-ins--voice-note msg (plist-get web-page :voice_note))
                (telega-ins "\n"))
-              ((and (not (zerop (plist-get web-page :story_sender_chat_id)))
-                    (not (zerop (plist-get web-page :story_id))))
+              ((and (not (telega-zerop (plist-get web-page :story_sender_chat_id)))
+                    (not (telega-zerop (plist-get web-page :story_id))))
                (telega-ins--story-content
                 (telega-story-get
                  (plist-get web-page :story_sender_chat_id)


### PR DESCRIPTION
Hello,

I faced an error when receiving a link as `story_id` and `story_sender_chat_id` are both nil. I don't know if it is due to the use of emacs 29[1], but by simply testing if the value is available in addition to different to 0, it seems to solve the problem


[1] GNU Emacs 29.1.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.38, cairo version 1.17.8) of 2023-09-01