### PR TITLE
[contrib] [tdlib 1.8.21] rename messageForward* -> message*

### DIFF
--- a/contrib/telega-adblock.el
+++ b/contrib/telega-adblock.el
@@ -229,7 +229,7 @@ an URL."
 (defun telega-adblock-msg-forwarded-p (msg)
   "Return non-nil if MSG is forwarded from another channel."
   (when-let ((fwd-origin (telega--tl-get msg :forward_info :origin))
-             (orig-chat-id (when (equal "messageForwardOriginChannel"
+             (orig-chat-id (when (equal "messageOriginChannel"
                                         (plist-get fwd-origin :@type))
                              (plist-get fwd-origin :chat_id))))
     ;; Allow self-forwards

--- a/contrib/telega-bridge-bot.el
+++ b/contrib/telega-bridge-bot.el
@@ -457,7 +457,7 @@ Will update CHAT-ID MSG-ID when download completed."
   (when-let* ((msg-id (telega--tl-get msg :id))
               (chat-id (telega--tl-get msg :chat_id))
               (forward-info (telega--tl-get msg :forward_info))
-              (fwd-info-p (eq (telega--tl-type forward-info) 'messageInfo))
+              (fwd-info-p (eq (telega--tl-type forward-info) 'messageForwardInfo))
               (bot-id (telega--tl-get forward-info :origin :sender_user_id))
               (counterparty-info (telega-bridge-bot--counterparty-info chat-id bot-id)) ; check if it is a bridge bot
               (counterparty-type (plist-get counterparty-info :type))

--- a/contrib/telega-bridge-bot.el
+++ b/contrib/telega-bridge-bot.el
@@ -457,7 +457,7 @@ Will update CHAT-ID MSG-ID when download completed."
   (when-let* ((msg-id (telega--tl-get msg :id))
               (chat-id (telega--tl-get msg :chat_id))
               (forward-info (telega--tl-get msg :forward_info))
-              (fwd-info-p (eq (telega--tl-type forward-info) 'messageForwardInfo))
+              (fwd-info-p (eq (telega--tl-type forward-info) 'messageInfo))
               (bot-id (telega--tl-get forward-info :origin :sender_user_id))
               (counterparty-info (telega-bridge-bot--counterparty-info chat-id bot-id)) ; check if it is a bridge bot
               (counterparty-type (plist-get counterparty-info :type))
@@ -473,7 +473,7 @@ Will update CHAT-ID MSG-ID when download completed."
               (body (cadr name-and-body))) ; skip if no body
     (let ((sender-id (telega-bridge-bot--update-user-info msg-id chat-id bot-id name)))
       ;; replace sender
-      (plist-put forward-info :origin (list :@type "messageForwardOriginUser" :sender_user_id sender-id))
+      (plist-put forward-info :origin (list :@type "messageOriginUser" :sender_user_id sender-id))
       ;; remove duplicated username in body
       (plist-put
        content :text

--- a/contrib/telega-emacs-stories.el
+++ b/contrib/telega-emacs-stories.el
@@ -433,9 +433,9 @@ If STORY-MESSAGES is not specified, unview all story messages."
 Return featured chat id, if MSG is featured."
   (when-let* ((origin (telega--tl-get msg :forward_info :origin))
               (chat-id (cl-case (telega--tl-type origin)
-                         (messageForwardOriginChat
+                         (messageOriginChat
                           (plist-get origin :sender_chat_id))
-                         (messageForwardOriginChannel
+                         (messageOriginChannel
                           (plist-get origin :chat_id)))))
     (car (memq chat-id telega-emacs-stories--featured-chat-ids))))
 


### PR DESCRIPTION
Rename all `messageForward*` to `message*`.