### PR TITLE
add if-C-u as an option for telega-chat-send-message-on-ret

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -4498,14 +4498,18 @@ use.  For example `C-u RET' will use
 Behaviour depends on point position and value for
 `telega-chat-send-message-on-ret'."
   (interactive)
-  (if (or (eq 'always telega-chat-send-message-on-ret)
+  (if (functionp telega-chat-send-message-on-ret)
+    (if (funcall telega-chat-send-message-on-ret)
+        (call-interactively #'telega-chatbuf-input-send)
+      (call-interactively #'newline))
+    (if (or
+          (eq 'always telega-chat-send-message-on-ret)
           (and (eobp)                   ;point at the end of the prompt
                (not (eq 'if-C-u telega-chat-send-message-on-ret)))
-          (and (or (eq 'if-at-the-end-or-C-u telega-chat-send-message-on-ret)
-                   (eq 'if-C-u telega-chat-send-message-on-ret))
+          (and (eq 'if-C-u telega-chat-send-message-on-ret)
                current-prefix-arg))
-      (call-interactively #'telega-chatbuf-input-send)
-    (call-interactively #'newline)))
+        (call-interactively #'telega-chatbuf-input-send)
+      (call-interactively #'newline))))
 
 (defun telega-chatbuf-input-insert (imc)
   "Insert input content defined by IMC into chatbuf input.

--- a/telega-chat.el
+++ b/telega-chat.el
@@ -4499,8 +4499,10 @@ Behaviour depends on point position and value for
 `telega-chat-send-message-on-ret'."
   (interactive)
   (if (or (eq 'always telega-chat-send-message-on-ret)
-          (eobp)                        ;point at the end of the prompt
-          (and (eq 'if-at-the-end-or-C-u telega-chat-send-message-on-ret)
+          (and (eobp)                   ;point at the end of the prompt
+               (not (eq 'if-C-u telega-chat-send-message-on-ret)))
+          (and (or (eq 'if-at-the-end-or-C-u telega-chat-send-message-on-ret)
+                   (eq 'if-C-u telega-chat-send-message-on-ret))
                current-prefix-arg))
       (call-interactively #'telega-chatbuf-input-send)
     (call-interactively #'newline)))

--- a/telega-customize.el
+++ b/telega-customize.el
@@ -1310,8 +1310,6 @@ Increasing this limit increases number of events telega needs to process."
   :type '(choice
           (const :tag "Always send a message" always)
           (const :tag "Send message if point at the end of prompt" if-at-the-end)
-          (const :tag "Send message if C-u is specified \
-or point at the end of prompt" if-at-the-end-or-C-u)
           (const :tag "Send message if C-u is specified" if-C-u))
   :package-version '(telega . "0.8.121")
   :group 'telega-chat)

--- a/telega-customize.el
+++ b/telega-customize.el
@@ -1311,7 +1311,8 @@ Increasing this limit increases number of events telega needs to process."
           (const :tag "Always send a message" always)
           (const :tag "Send message if point at the end of prompt" if-at-the-end)
           (const :tag "Send message if C-u is specified \
-or point at the end of prompt" if-at-the-end-or-C-u))
+or point at the end of prompt" if-at-the-end-or-C-u)
+          (const :tag "Send message if C-u is specified" if-C-u))
   :package-version '(telega . "0.8.121")
   :group 'telega-chat)
 


### PR DESCRIPTION
it would be great if you could accept this option.

I'm used to sending messages with `shift-enter` in gui client because I tend to send multi-line text mostly and to keep in mind that enter works on `(eobp)` all the time is very tedious.

thanks!