### PR TITLE
[fix] error "transient-define-*: Interactive form missing"

### DIFF
--- a/telega-util.el
+++ b/telega-util.el
@@ -3079,10 +3079,10 @@ Return nil if there is no tags for the SM-TOPIC-ID or new tag is choosen."
    (telega-saved-messages-tag-add-name)
    (telega-saved-messages-tag-remove)
    ]
-  (lambda (tag)
+  [(lambda (tag)
     (interactive (list (user-error "Do not call this command directly")))
     ;; (transient-setup 'telega-saved-messages-tag-commands nil nil :scope (cons tag msg))
-    ))
+    )])
 
 
 ;;; Stipple drawing


### PR DESCRIPTION
without this telega does not start anymore
fixes #472

In contrast to #473  this does not make concerning function `(interactive)` and instead just add `[]`.