### PR TITLE
Compatible with podman 5.2.0, check device existence.

### DIFF
--- a/telega-util.el
+++ b/telega-util.el
@@ -2703,9 +2703,12 @@ Binds current symbol to SYM-BIND."
         " --net=host"
         ;; Add host devices to container to allow voice/video
         ;; recording
-        " --device /dev/snd:/dev/snd"
-        " --device /dev/video0:/dev/video0"
-        " --device /dev/video1:/dev/video1"
+        (when (file-exists-p "/dev/snd")
+          " --device /dev/snd:/dev/snd")
+        (when (file-exists-p "/dev/video0")
+          " --device /dev/video0:/dev/video0")
+        (when (file-exists-p "/dev/video1")
+          " --device /dev/video1:/dev/video1")
 
         ;; Export resources for pulseaudio to work
         ;; ref: https://stackoverflow.com/questions/28985714/run-apps-using-audio-in-a-docker-container


### PR DESCRIPTION
In Podman 5.2.0, adding non-existent devices will throw an error.

> The --device option to podman create and podman run is no longer ignored when --privileged is also specified (https://github.com/containers/podman/issues/23132).

This PR will check if the device exists when add host devices to container.