### PR TITLE
fix forwarding

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -5913,7 +5913,7 @@ then forward message copy without caption."
                            (when-let ((msg-at-point (telega-msg-at (point))))
                              (list msg-at-point)))))
     ;; NOTE: ExcludeEvery
-    (unless (seq-every-p (telega--tl-prop :can_be_forwarded) messages)
+    (unless (seq-every-p (telega--tl-prop :can_be_saved) messages)
       (user-error "telega: Forwarding is not allowed"))
 
     (let ((chat (telega-completing-read-chat


### PR DESCRIPTION
Currently the flag `can_be_forwarded` is checked upon forwarding messages in a chat, but it is discarded in the latest version of TDLib, causing forwarding messages to be impossible. Checking `can_be_saved` is equivalent.