### PR TITLE
add `telega-chat-skip-delete-confirmation-for` custom option

### DIFF
--- a/docs/telega-ellit.org
+++ b/docs/telega-ellit.org
@@ -573,6 +573,7 @@ Use ~telega-story-match-p~ to match a story.
 - {{{user-option(telega-chat-group-messages-for, 2)}}}
 - {{{user-option(telega-chat-show-deleted-messages-for, 2)}}}
 - {{{user-option(telega-root-view-grouping-alist, 2)}}}
+- {{{user-option(telega-chat-delete-skip-confirmation-for, 2)}}}
 
 * Chat Folders
 

--- a/telega-chat.el
+++ b/telega-chat.el
@@ -1337,8 +1337,8 @@ If MUTED-FOR is specified, set it as `:mute_for' notification setting."
 
 (defun telega-chat-delete (chat)
   "Delete CHAT.
-Query about everything.  Leaving CHAT, blocking corresponding
-user and delete all the chat history.
+Query about everything: leaving CHAT, blocking corresponding
+user, and deleting all chat history.
 Use `telega-chat-leave' to just leave the CHAT."
   (interactive (list (or telega-chatbuf--chat (telega-chat-at (point)))))
   (when (and chat
@@ -1367,9 +1367,10 @@ Use `telega-chat-leave' to just leave the CHAT."
                (not (telega-chat-match-p chat
                       '(or (type channel)
                            (and (type supergroup) is-public))))
-               (telega-read-im-sure-p
-                (telega-i18n "telega_query_delete_chat_history"
-                  :title (telega-chat-title chat))))
+               (or (telega-chat-match-p chat telega-chat-delete-skip-confirmation-for)
+                   (telega-read-im-sure-p
+                     (telega-i18n "telega_query_delete_chat_history"
+                       :title (telega-chat-title chat)))))
       (let ((revoke-p (and (plist-get chat :can_be_deleted_for_all_users)
                            (y-or-n-p "Delete history for all members? "))))
         (telega--deleteChatHistory chat 'remove-from-list revoke-p)))

--- a/telega-customize.el
+++ b/telega-customize.el
@@ -215,6 +215,13 @@ Tracking notifications for telega buffers will use the
              (or unmuted mention))
   :group 'telega)
 
+(defcustom telega-chat-delete-skip-confirmation-for nil
+  "*Specifies Chat Temex for chats which can be deleted without
+typing confirmation."
+  :package-version '(telega . "0.8.293")
+  :type 'telega-chat-temex
+  :group 'telega-chat)
+
 (defcustom telega-image-transform-smoothing t
   "Default value for the `:transform-smoothing' image property.
 If nil, then smoothing is applied only for downscaled images, if image


### PR DESCRIPTION
specifies Chat Temex for chats which can be deleted without typing confirmation