### PR TITLE
fix  file reference and time of getting properties 

### DIFF
--- a/telega-msg.el
+++ b/telega-msg.el
@@ -1704,39 +1704,31 @@ Saved Messages."
 
       ;; NOTE: Start downloading file in the background while reading
       ;; filename
-      (unless (telega-file--downloaded-p file)
-        (telega-file--download file
-          :priority 32
-          :update-callback
-          (lambda (_dfile)
-            (telega-msg-redisplay msg))))
-
-      (let* ((fname (file-name-nondirectory
-                     (telega--tl-get file :local :path)))
-             (new-fpath
-              (if (and telega-msg-save-dir (not (string-empty-p fname)))
-                  (expand-file-name fname telega-msg-save-dir)
-                (read-file-name (concat (telega-i18n "lng_save_file") ": ")
-                                (or telega-msg-save-dir default-directory)
-                                nil nil fname))))
-        ;; NOTE: Ensure corresponding directory exists
-        (let ((fdir (file-name-directory new-fpath)))
-          (unless (file-exists-p fdir)
-            (if (y-or-n-p
-                 (format-message
-                  "Directory `%s' does not exist; create? " fdir))
-                (make-directory fdir t)
-              (error "Canceled"))))
-
-        ;; See https://github.com/tdlib/td/issues/379
-        (telega-file--download file
-          :priority 32
-          :update-callback
-          (lambda (dfile)
-            (when (telega-file--downloaded-p dfile)
+      ;; See https://github.com/tdlib/td/issues/379
+      (telega-file--download file
+        :priority 32
+        :update-callback
+        (lambda (dfile)
+          (telega-msg-redisplay msg)
+          (when (telega-file--downloaded-p dfile)
+            (let* ((fname (file-name-nondirectory
+                           (telega--tl-get dfile :local :path)))
+                   (new-fpath
+                    (if (and telega-msg-save-dir (not (string-empty-p fname)))
+                        (expand-file-name fname telega-msg-save-dir)
+                      (read-file-name (concat (telega-i18n "lng_save_file") ": ")
+                                      (or telega-msg-save-dir default-directory)
+                                      nil nil fname))))
+              ;; NOTE: Ensure corresponding directory exists
+              (let ((fdir (file-name-directory new-fpath)))
+                (unless (file-exists-p fdir)
+                  (if (y-or-n-p
+                       (format-message
+                        "Directory `%s' does not exist; create? " fdir))
+                      (make-directory fdir t)
+                    (error "Canceled"))))
               (copy-file (telega--tl-get dfile :local :path) new-fpath 1)
-              (message (format "Wrote %s" new-fpath)))))
-        )))))
+              (message (format "Wrote %s" new-fpath))))))))))
 
 (defun telega-msg-copy-link (msg &optional for-thread-p)
   "Copy link to message to kill ring.


### PR DESCRIPTION
Thank for your patches on #519. But it doesn't really fix the issue.

fname and new-fpath are get from file, before finished download, where they are always fetched wrong values, especially on fname that is always empty.
They should be set in callback functions to get the correct value which are set in `telega-file--download`.
I recreate pr #524 without conflictions.