### PR TITLE
enable callback for getCallbackQueryAnswer

### DIFF
--- a/telega-inline.el
+++ b/telega-inline.el
@@ -60,7 +60,7 @@
       (when link
         (telega-browse-url link)))))
 
-(cl-defun telega--getCallbackQueryAnswer (msg payload &key (callback #'ignore))
+(cl-defun telega--getCallbackQueryAnswer (msg payload &key (callback #'telega--on-callbackQueryAnswer))
   "Async send callback to bot."
   (declare (indent 2))
   (telega-server--call


### PR DESCRIPTION
I've noticed that clicking on a captcha bot's button I don't receive any feedback. Mobile client properly shows that I'm not authorized to use the button.
Telega logs indicate the message is received, but not handled:

```
1769623557: event IN: (:@type "callbackQueryAnswer" :text "You don't have permission to complete this CAPTCHA." :@extra 133)
```