### PR TITLE
fix: correct mpv video play incrementally

### DIFF
--- a/telega-customize.el
+++ b/telega-customize.el
@@ -638,7 +638,9 @@ NOT USED."
         ((executable-find "mpv")
          '(concat "mpv"
                   (when telega-ffplay-media-timestamp
-                    (format " --start=%f" telega-ffplay-media-timestamp))))
+                    (format " --start=%f" telega-ffplay-media-timestamp))
+                  (when telega-video-play-incrementally
+                    " --cache=no")))
         ((executable-find "mplayer")
          '(concat "mplayer"
                   (when telega-ffplay-media-timestamp


### PR DESCRIPTION
During cache usage, video playback breaks when it reaches the initially available maximum playback position. With cache disabled, video playback continues without issues.