### PR TITLE
Support cycling through multiple playback speeds for voice/video notes

### DIFF
--- a/telega-ins.el
+++ b/telega-ins.el
@@ -975,7 +975,7 @@ If NO-2X-BUTTON is specified, then do not display \"2x\" button."
               (telega-msg--vvnote-rewind msg 10)))
   (telega-ins " ")
   (unless no-2x-button
-    (let* ((label2x (format "%g×" telega-vvnote-play-speed))
+    (let* ((label2x (format "%g×" telega-vvnote--play-speed))
            (ends (if (functionp telega-box-button-endings)
                      (funcall telega-box-button-endings label2x)
                    telega-box-button-endings)))

--- a/telega-msg.el
+++ b/telega-msg.el
@@ -639,19 +639,19 @@ Return nil for deleted messages."
 (defun telega-msg-voice-note--ffplay-callback (proc msg &optional
                                                     no-progress-adjust)
   "Callback for voice/video note.
-Adjust progress according to the `telega-vvnote-play-speed'.
+Adjust progress according to the `telega-vvnote--play-speed'.
 Also, start playing next voice/video note when active voice/video
 note finishes."
-  ;; NOTE: adjust `:progress' with `telega-vvnote-play-speed'
+  ;; NOTE: adjust `:progress' with `telega-vvnote--play-speed'
   ;; since ffplay reports progress disreguarding atempo
   (unless no-progress-adjust
     (when-let* ((proc-plist (process-plist proc))
                 (progress (plist-get proc-plist :progress))
                 (resumed-at (or (plist-get msg :telega-ffplay-resumed-at) 0)))
       (cl-assert (numberp progress))
-      (unless (equal 1 telega-vvnote-play-speed)
+      (unless (equal 1 telega-vvnote--play-speed)
         (setq progress (+ resumed-at (* (- progress resumed-at)
-                                        telega-vvnote-play-speed)))
+                                        telega-vvnote--play-speed)))
         (set-process-plist proc (plist-put proc-plist :progress progress)))))
 
   (telega-msg-redisplay msg)
@@ -709,9 +709,9 @@ note finishes."
                            (concat
                             (when paused-p
                               (format "-ss %.2f " paused-p))
-                            (unless (equal telega-vvnote-play-speed 1)
+                            (unless (equal telega-vvnote--play-speed 1)
                               (format "-af atempo=%.2f "
-                                      telega-vvnote-play-speed))
+                                      telega-vvnote--play-speed))
                             (cdr (assq 'voice-note
                                        telega-open-message-ffplay-args)))
                          (lambda (proc)
@@ -800,13 +800,13 @@ non-nil."
                            (telega-file--path file)
                            (concat
                             "-vf scale=120:120"
-                            (unless (equal telega-vvnote-play-speed 1)
+                            (unless (equal telega-vvnote--play-speed 1)
                               (format " -af atempo=%.2f"
-                                      telega-vvnote-play-speed))
+                                      telega-vvnote--play-speed))
                             (concat " -f " (car telega-vvnote--has-audio-inputs))
                             " default -vsync 0")
                          (list #'telega-msg-video-note--ffplay-callback msg)
-                         :seek paused-p :speed telega-vvnote-play-speed))
+                         :seek paused-p :speed telega-vvnote--play-speed))
             (with-telega-chatbuf (telega-msg-chat msg)
               (telega-chatbuf--activate-vvnote-msg msg)))
 

--- a/telega-vvnote.el
+++ b/telega-vvnote.el
@@ -39,13 +39,13 @@
   :type '(cons color color)
   :group 'telega-vvnote)
 
-(defcustom telega-vvnote-play-speeds '(1 1.5 2)
+(defcustom telega-vvnote-play-speeds '(1 1.8)
   "List of playback speeds to cycle through for voice/video notes."
   :package-version '(telega . "0.8.602")
   :type '(repeat number)
   :group 'telega-vvnote)
 
-(defvar telega-vvnote-play-speed 1
+(defvar telega-vvnote--play-speed 1
   "Current playback speed for voice/video notes.")
 
 (defcustom telega-vvnote-play-next t
@@ -582,9 +582,9 @@ Return filename with recorded video note."
 Cycles through speeds defined in `telega-vvnote-play-speeds'."
   (interactive (list (telega-msg-for-interactive)))
   (when-let ((proc (plist-get msg :telega-ffplay-proc)))
-    (let ((tail (cdr (member telega-vvnote-play-speed
+    (let ((tail (cdr (member telega-vvnote--play-speed
                              telega-vvnote-play-speeds))))
-      (setq telega-vvnote-play-speed
+      (setq telega-vvnote--play-speed
             (if tail (car tail) (car telega-vvnote-play-speeds))))
     (telega-msg-redisplay msg)
     ;; Restart ffplay by reopening message content


### PR DESCRIPTION
## Summary
- Replace the binary 1x/2x speed toggle with a configurable cycle through multiple speeds
- Add `telega-vvnote-play-speeds` defcustom (default: 1, 1.5, 2) to let users choose which speeds to cycle through
- Update the button label to show the actual current speed instead of hard-coded "1×"/"2×"

## Test plan
- [ ] Play a voice note, press `x` repeatedly — speed cycles through configured list
- [ ] Button label updates to show current speed (e.g. "1.5×")
- [ ] Customize `telega-vvnote-play-speeds` to a different list, confirm it's respected
- [ ] After cycling past the last speed, wraps back to the first