### PR TITLE
telega-bridge-bot: use defconst for auth download endpoint

### DIFF
--- a/contrib/telega-bridge-bot.el
+++ b/contrib/telega-bridge-bot.el
@@ -116,7 +116,7 @@
   "%s/_matrix/media/v3/download/%s") ; mxc id
 (defvar telega-bridge-bot--matrix-media-thumbnail-endpoint
   "%s/_matrix/media/v3/thumbnail/%s?width=96&height=96&method=crop") ; mxc id
-(defvar telega-bridge-bot--matrix-media-auth-download-endpoint
+(defconst telega-bridge-bot--matrix-media-auth-download-endpoint
   "%s/_matrix/client/v1/media/download/%s"
   "Authenticated Matrix media download endpoint (MSC3916 / Matrix 1.11).")
 


### PR DESCRIPTION
Use `defconst` instead of `defvar` for                                                                                                                                                                                                                                                                                                                                     
  `telega-bridge-bot--matrix-media-auth-download-endpoint` as it is a                                                                                                                                                                                                                                                                                                        
  compile-time constant that is not intended to be modified at runtime.                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                             
  Suggested by @zevlg in [#550](https://github.com/zevlg/telega.el/pull/550#issuecomment-3964812037).