### PR TITLE
Fix typo

### DIFF
--- a/telega-tdlib-events.el
+++ b/telega-tdlib-events.el
@@ -1345,7 +1345,7 @@ Please downgrade TDLib and recompile `telega-server'"
          (telega-debug "docker RUN: %s" devices-chown-cmd)
          (shell-command-to-string devices-chown-cmd))
 
-       (run-hook 'telega-before-auth-hook)
+       (run-hooks 'telega-before-auth-hook)
 
        (telega--setTdlibParameters))
 


### PR DESCRIPTION
Fix
```
error: (void-function run-hook)
```