### PR TITLE
fix(completions): init emoji in CAPF setup, not per-invocation

### DIFF
--- a/telega-completions.el
+++ b/telega-completions.el
@@ -568,7 +568,6 @@ Handles repeated leading CHARs (e.g. @@).  Returns nil if not applicable."
              (= (match-beginning 0) telega-chatbuf--input-marker))
     (cons (match-beginning 0) (point))))
 
-
 ;;; CAPF: local emoji (:<name>:)
 
 (defun telega-capf-emoji ()
@@ -583,7 +582,6 @@ Handles repeated leading CHARs (e.g. @@).  Returns nil if not applicable."
                             (match-beginning 1))))
               (prefix (buffer-substring-no-properties start end))
               ((string-prefix-p ":" prefix)))
-    (telega-emoji-init)
     (let ((candidates
            (telega-completions--emoji-candidates
             prefix telega-completions-emoji-fuzzy-match)))
@@ -771,6 +769,9 @@ Handles repeated leading CHARs (e.g. @@).  Returns nil if not applicable."
 (defun telega-completions-setup-capf ()
   "Add telega CAPF functions to `completion-at-point-functions'.
 Intended for use in `telega-chat-mode-hook'."
+  (when (or (memq 'telega-capf-emoji telega-completions-capf-functions)
+            (memq 'telega-capf-telegram-emoji telega-completions-capf-functions))
+    (telega-emoji-init))
   (setq-local completion-at-point-functions
               (append telega-completions-capf-functions
                       completion-at-point-functions)))

--- a/test.el
+++ b/test.el
@@ -282,6 +282,57 @@ Have Stoploss 690 Satoshi." :entities []))))
     (should (equal (external-completion--all-completions "you" table nil 3)
                    '("i-love-you")))))
 
+(ert-deftest telega-capf-emoji-finds-completions-after-init ()
+  "Local emoji CAPF should find completions after emoji init."
+  (with-temp-buffer
+    (insert " :rocket")
+    (goto-char (point-max))
+    (let ((telega-emoji-alist nil)
+          (telega-emoji-candidates nil)
+          (telega-emoji-candidate-max-length 0))
+      (cl-letf (((symbol-function 'telega-emoji-init)
+                 (lambda ()
+                   (setq telega-emoji-alist '((":rocket:" . "\xF0\x9F\x9A\x80"))
+                         telega-emoji-candidates '(":rocket:")
+                         telega-emoji-candidate-max-length
+                         (length ":rocket:")))))
+        (funcall (symbol-function 'telega-emoji-init))
+        (let ((capf (telega-capf-emoji)))
+          (should capf)
+          (should (equal (buffer-substring-no-properties
+                          (nth 0 capf)
+                          (nth 1 capf))
+                         ":rocket"))
+          (should (equal (nth 2 capf)
+                         '(":rocket:"))))))))
+
+(ert-deftest telega-capf-telegram-emoji-finds-completions-after-init ()
+  "Telegram emoji CAPF should find completions after emoji init."
+  (with-temp-buffer
+    (insert " :rocket")
+    (goto-char (point-max))
+    (let ((telega-emoji-alist nil)
+          (telega-emoji-candidates nil)
+          (telega-emoji-candidate-max-length 0))
+      (cl-letf (((symbol-function 'telega-emoji-init)
+                 (lambda ()
+                   (setq telega-emoji-alist '((":rocket:" . "\xF0\x9F\x9A\x80"))
+                         telega-emoji-candidates '(":rocket:")
+                         telega-emoji-candidate-max-length
+                         (length ":rocket:"))))
+                ((symbol-function 'telega-completions--ensure-external-completion)
+                 (lambda () t))
+                ((symbol-function 'external-completion-table)
+                 (lambda (&rest _args) 'telegram-emoji-table)))
+        (funcall (symbol-function 'telega-emoji-init))
+        (let ((capf (telega-capf-telegram-emoji)))
+          (should capf)
+          (should (equal (buffer-substring-no-properties
+                          (nth 0 capf)
+                          (nth 1 capf))
+                         ":rocket"))
+          (should (eq (nth 2 capf) 'telegram-emoji-table)))))))
+
 (ert-deftest telega-bot-chat-with-topics-is-forum ()
   "Bot chats with topics enabled should reuse forum topic support."
   (let* ((bot-id 90901)


### PR DESCRIPTION
## Summary

- Move `telega-emoji-init` from `telega-capf-emoji` and `telega-capf-telegram-emoji` into `telega-completions-setup-capf`, where it runs once at setup time
- Only inits emoji when an emoji CAPF function is present in `telega-completions-capf-functions`
- Removes redundant per-invocation init calls that previously ran on every completion request

## Test plan

- [x] All 20 existing tests pass including updated emoji CAPF tests
- [ ] Verify emoji completion works in a chat buffer with CAPF
- [ ] Verify emoji completion still works with company backend