### PR TITLE
telega-server: run gtk_init_check in the appindicator loop thread

### DIFF
--- a/server/telega-appindicator.c
+++ b/server/telega-appindicator.c
@@ -31,7 +31,6 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <assert.h>
 
 #ifdef WITH_AYATANA_APPINDICATOR
@@ -134,15 +133,19 @@ telega_appindicator_send(const char* json)
         g_idle_add(appindicator_cmd, json_copy);
 }
 
-bool
-telega_appindicator_init(void)
-{
-        return gtk_init_check(NULL, NULL);
-}
-
 void*
 telega_appindicator_loop(void* data)
 {
+        /* GTK initialization and the GMainLoop driving its events
+         * must run on the same thread (GTK is not thread-safe and
+         * must be used from the thread that called gtk_init).
+         * Otherwise idle callbacks scheduled via g_idle_add from
+         * telega_appindicator_send are not dispatched. */
+        if (!gtk_init_check(NULL, NULL)) {
+                /* No display (e.g. running in tty), nothing to do. */
+                fprintf(stderr, "[telega-appindicator] disabled, no display\n");
+                return NULL;
+        }
         loop = g_main_loop_new(NULL, FALSE);
         g_main_loop_run(loop);
         return NULL;

--- a/server/telega-server.c
+++ b/server/telega-server.c
@@ -37,7 +37,6 @@ extern int telega_voip_cmd(const char* json);
 #endif /* WITH_VOIP */
 
 #ifdef WITH_APPINDICATOR
-extern bool telega_appindicator_init(void);
 extern void telega_appindicator_send(const char* json);
 extern void* telega_appindicator_loop(void* data);
 extern void telega_appindicator_stop(void);
@@ -463,13 +462,10 @@ main(int ac, char** av)
         assert(rc == 0);
 
 #ifdef WITH_APPINDICATOR
-        bool has_appind = telega_appindicator_init();
         pthread_t appind_thread;
-        if (has_appind) {
-                rc = pthread_create(&appind_thread, NULL,
-                                    telega_appindicator_loop, NULL);
-                assert(rc == 0);
-        }
+        rc = pthread_create(&appind_thread, NULL,
+                            telega_appindicator_loop, NULL);
+        assert(rc == 0);
 #endif /* WITH_APPINDICATOR */
 
         stdin_loop(tdlib_cln);
@@ -482,11 +478,9 @@ main(int ac, char** av)
         td_json_client_destroy(tdlib_cln);
 
 #ifdef WITH_APPINDICATOR
-        if (has_appind) {
-                telega_appindicator_stop();
-                rc = pthread_join(appind_thread, NULL);
-                assert(rc == 0);
-        }
+        telega_appindicator_stop();
+        rc = pthread_join(appind_thread, NULL);
+        assert(rc == 0);
 #endif /* WITH_APPINDICATOR */
 
         return 0;


### PR DESCRIPTION
GTK's documented threading rules require GTK initialization, the GMainLoop driving the events, and any GTK / libappindicator calls to all happen on the same thread (see "GTK+ is not thread safe, and you should only use GTK+ and GDK from the thread gtk_init() and gtk_main() were called on", https://docs.gtk.org/glib/struct.MainContext.html and the GTK threading docs).

Previously gtk_init_check() ran in the main thread while telega_appindicator_loop() ran g_main_loop_run() in a separate pthread, splitting initialization and event dispatch across two threads.  As a result, idle callbacks scheduled from the main thread by telega_appindicator_send() via g_idle_add() (which targets the global default GMainContext that GTK has set up) were not dispatched by the loop, so "setup", "status", "icon" and "label" commands were silently dropped and no tray icon was ever shown.

Move gtk_init_check() into telega_appindicator_loop() so initialization and the main loop both live on the same thread, matching GTK's threading model.