### PR TITLE
Ignore missing chats in last message updates

### DIFF
--- a/telega-tdlib-events.el
+++ b/telega-tdlib-events.el
@@ -374,29 +374,29 @@ DIRTINESS specifies additional CHAT dirtiness."
   (let* ((chat-id (plist-get event :chat_id))
          (chat (telega-chat-get chat-id 'offline))
          (event-last-msg (plist-get event :last_message)))
-    (cl-assert chat)
-    ;; NOTE: If chat's last message is already in the message's
-    ;; cache, use it, because various logic (such as ignoring
-    ;; predicated) might be already applied to the message
-    (when event-last-msg
-      (when-let ((cached-last-msg
-                  (gethash (cons chat-id (plist-get event-last-msg :id))
-                           telega--cached-messages)))
-        (setq event-last-msg cached-last-msg)))
+    (when chat
+      ;; NOTE: If chat's last message is already in the message's
+      ;; cache, use it, because various logic (such as ignoring
+      ;; predicated) might be already applied to the message
+      (when event-last-msg
+        (when-let ((cached-last-msg
+                    (gethash (cons chat-id (plist-get event-last-msg :id))
+                             telega--cached-messages)))
+          (setq event-last-msg cached-last-msg)))
 
-    (plist-put chat :last_message event-last-msg)
-    (plist-put chat :positions (plist-get event :positions))
+      (plist-put chat :last_message event-last-msg)
+      (plist-put chat :positions (plist-get event :positions))
 
-    ;; NOTE: `:last_message' is unset when gap is created in the chat
-    ;; This case is handled in the `telega-chatbuf--last-msg-loaded-p'
-    ;; See https://github.com/tdlib/td/issues/896
-    ;;
-    ;; Gap can be also created if last message in the chat is deleted.
-    ;; TDLib might take some time to update chat's last message.
-    (with-telega-chatbuf chat
-      (telega-chatbuf--history-state-delete :newer-loaded))
+      ;; NOTE: `:last_message' is unset when gap is created in the chat
+      ;; This case is handled in the `telega-chatbuf--last-msg-loaded-p'
+      ;; See https://github.com/tdlib/td/issues/896
+      ;;
+      ;; Gap can be also created if last message in the chat is deleted.
+      ;; TDLib might take some time to update chat's last message.
+      (with-telega-chatbuf chat
+        (telega-chatbuf--history-state-delete :newer-loaded))
 
-    (telega-chat--mark-dirty chat event)))
+      (telega-chat--mark-dirty chat event))))
 
 (defun telega--on-updateChatIsMarkedAsUnread (event)
   (let ((chat (telega-chat-get (plist-get event :chat_id) 'offline)))


### PR DESCRIPTION
## Summary

- Avoid asserting when `updateChatLastMessage` references a chat that is not present in the local cache.
- Skip the update in that case instead of trying to mutate and mark a nil chat.

## Rationale

TDLib can emit chat update events for chats that are not currently known locally. In that case `telega-chat-get` with the `offline` flag returns nil, and the existing `cl-assert` aborts update processing. Treating the missing chat as a no-op keeps the event handler robust while preserving the existing behavior for cached chats.
