### PR TITLE
Fix byte/native compilation of `telega-transient.el`

### DIFF
--- a/telega-transient.el
+++ b/telega-transient.el
@@ -1873,8 +1873,9 @@ Return first applicable imc."
   :type '(repeat symbol)
   :group 'telega-modes)
 
-(defun telega-transient--keymap-prefix-name (keymap-symbol)
-  (intern (format "telega-transient--prefix-%S" keymap-symbol)))
+(eval-and-compile
+  (defun telega-transient--keymap-prefix-name (keymap-symbol)
+    (intern (format "telega-transient--prefix-%S" keymap-symbol))))
 
 (defun telega-transient--keymap-setup-children (keymap-symbol)
   (let ((keymap (symbol-value keymap-symbol)))


### PR DESCRIPTION
During compilation, the helper `telega-transient--keymap-prefix-name` is not yet available to the macro expander (in `telega-transient-define-prefix-by-keymap` macro), resulting in error:

```
Symbol’s function definition is void: telega-transient--keymap-prefix-name
```

Wrapping the `telega-transient--keymap-prefix-name` in `eval-and-compile` ensures it is available when the macro is expanded, fixing the error.