### PR TITLE
Fix chat completion fallback after sticker lookup

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -6921,8 +6921,8 @@ To be used in the `telega-chat-input-complete-functions'."
       ;;                    (string= emoji telega-help-win--emoji))))
       (telega-sticker-choose-emoji emoji telega-chatbuf--chat
                                    (not (string= (telega-chatbuf-input-string)
-                                                 emoji)))))
-      t)
+                                                 emoji)))
+      t)))
 
 (defun telega-chatbuf-complete ()
   "Complete thing at chatbuf input."


### PR DESCRIPTION
telega-chatbuf-complete-sticker-by-emoji returned t even when the input was not an emoji. Since it runs before completion-at-point, this stopped the completion chain and broke TAB completion for mentions such as @ and @@.

Return t only when sticker completion actually handles an emoji.

Test: make test_el (19/19 passed).