### PR TITLE
Add bulk actions for chat join requests

### DIFF
--- a/etc/langs/en.plist
+++ b/etc/langs/en.plist
@@ -1205,8 +1205,6 @@ Example: 23 y.o. designer from San Francisco")
   :value "Approve All")
  ("telega_group_requests_decline_all"
   :value "Decline All")
- ("telega_group_requests_processing"
-  :value "Processing…")
  ("telega_query_group_requests_approve_all"
   :one_value "Approve all {count} request to join «{title}»?"
   :other_value "Approve all {count} requests to join «{title}»?")

--- a/etc/langs/en.plist
+++ b/etc/langs/en.plist
@@ -1201,6 +1201,19 @@ Example: 23 y.o. designer from San Francisco")
  ("lng_group_requests_dismiss"
   :value "Dismiss")
 
+ ("telega_group_requests_approve_all"
+  :value "Approve All")
+ ("telega_group_requests_decline_all"
+  :value "Decline All")
+ ("telega_group_requests_processing"
+  :value "Processing…")
+ ("telega_query_group_requests_approve_all"
+  :one_value "Approve all {count} request to join «{title}»?"
+  :other_value "Approve all {count} requests to join «{title}»?")
+ ("telega_query_group_requests_decline_all"
+  :one_value "Decline all {count} request to join «{title}»?"
+  :other_value "Decline all {count} requests to join «{title}»?")
+
  ("lng_channel_invite_subscription_title"
   :value "Subscribe to the Channel")
  ("lng_channel_invite_subscription_about"

--- a/etc/langs/zh.plist
+++ b/etc/langs/zh.plist
@@ -1372,6 +1372,21 @@
  ("lng_group_requests_dismiss"
   :value "忽略")
 
+ ("telega_group_requests_approve_all"
+  :value "全部批准")
+
+ ("telega_group_requests_decline_all"
+  :value "全部拒绝")
+
+ ("telega_group_requests_processing"
+  :value "正在处理…")
+
+ ("telega_query_group_requests_approve_all"
+  :value "是否批准 «{title}» 的全部 {count} 个入群申请？")
+
+ ("telega_query_group_requests_decline_all"
+  :value "是否拒绝 «{title}» 的全部 {count} 个入群申请？")
+
  ("lng_group_requests_none"
   :value "暂无待处理的加入请求。")
 

--- a/etc/langs/zh.plist
+++ b/etc/langs/zh.plist
@@ -1378,9 +1378,6 @@
  ("telega_group_requests_decline_all"
   :value "全部拒绝")
 
- ("telega_group_requests_processing"
-  :value "正在处理…")
-
  ("telega_query_group_requests_approve_all"
   :value "是否批准 «{title}» 的全部 {count} 个入群申请？")
 

--- a/telega-chat.el
+++ b/telega-chat.el
@@ -2304,8 +2304,9 @@ Use this to surrond header with some prefix and suffix."
                   (plist-put telega-chatbuf--hidden-headers
                              :pending-join-requests nrequests)
                   (telega-chatbuf--chat-update "updateChatPendingJoinRequests")))
-      (telega-ins " " (telega-i18n "lng_manage_peer_requests") ": ")
-      (telega-ins--chat-pending-join-requests telega-chatbuf--chat jr-info)
+      (telega-ins " ")
+      (telega-ins--chat-pending-join-requests
+       telega-chatbuf--chat jr-info 'with-title)
       (telega-ins "\n"))))
 
 (defun telega-chatbuf-footer-ins-action-bar ()

--- a/telega-info.el
+++ b/telega-info.el
@@ -1474,72 +1474,29 @@ SETTING is one of `show-status', `allow-chat-invites' or `allow-calls'."
     (setq telega--help-win-inserter #'telega-describe-quick-replies--inserter)
     ))
 
-(defvar-local telega-describe-chat-join-requests--processing nil
-  "Identifiers of chats with join requests currently being processed.")
-
-(defun telega-describe-chat-join-requests--process-all-next
-    (chat previous-count approve-p buffer)
-  "Process the next batch of CHAT join requests.
-PREVIOUS-COUNT is the number before this batch, APPROVE-P specifies
-the action, and BUFFER is the join requests buffer."
-  (let* ((chat-id (plist-get chat :id))
-         (finish
-          (lambda (&optional error-message)
-            (when (buffer-live-p buffer)
-              (with-current-buffer buffer
-                (setq telega-describe-chat-join-requests--processing
-                      (delete chat-id
-                              telega-describe-chat-join-requests--processing)))
-              (telega-describe-chat-join-requests chat))
-            (when error-message
-              (message "telega: %s" error-message)))))
-    (telega--processChatJoinRequests chat approve-p
-      (lambda (reply)
-        (if (telega--tl-error-p reply)
-            (funcall finish (plist-get reply :message))
-          (telega--getChatJoinRequests chat :limit 1
-            :callback
-            (lambda (join-requests)
-              (if (telega--tl-error-p join-requests)
-                  (funcall finish (plist-get join-requests :message))
-                (let ((remaining (plist-get join-requests :total_count)))
-                  (if (or (zerop remaining)
-                          (>= remaining previous-count))
-                      (funcall finish)
-                    (telega-describe-chat-join-requests--process-all-next
-                     chat remaining approve-p buffer)))))))))))
-
 (defun telega-describe-chat-join-requests--process-all
     (chat nrequests approve-p)
   "Process all NREQUESTS pending join requests in CHAT.
 APPROVE-P is non-nil to approve the requests and nil to decline them."
-  (let ((chat-id (plist-get chat :id)))
-    (if (member chat-id telega-describe-chat-join-requests--processing)
-        (message "%s" (telega-i18n "telega_group_requests_processing"))
-      (when (yes-or-no-p
-             (concat
-              (unless approve-p
-                (concat (telega-i18n "telega_action_cant_undone") "\n"))
-              (telega-i18n
-                  (if approve-p
-                      "telega_query_group_requests_approve_all"
-                    "telega_query_group_requests_decline_all")
-                :count nrequests
-                :title (telega-chat-title chat))
-              " "))
-        (push chat-id telega-describe-chat-join-requests--processing)
-        (let ((buffer (current-buffer)))
-          (telega-describe-chat-join-requests chat)
-          (telega-describe-chat-join-requests--process-all-next
-           chat nrequests approve-p buffer))))))
+  (when (yes-or-no-p
+         (concat
+          (unless approve-p
+            (concat (telega-i18n "telega_action_cant_undone") "\n"))
+          (telega-i18n
+              (if approve-p
+                  "telega_query_group_requests_approve_all"
+                "telega_query_group_requests_decline_all")
+            :count nrequests
+            :title (telega-chat-title chat))
+          " "))
+    (telega--processChatJoinRequests chat approve-p
+      (lambda (_reply)
+        (telega-describe-chat-join-requests chat)))))
 
 (defun telega-describe-chat-join-requests--inserter (chat)
   "Inserter for the CHAT's pending join requests."
   (let* ((join-requests (telega--getChatJoinRequests chat))
-         (nrequests (plist-get join-requests :total_count))
-         (processing-p
-          (member (plist-get chat :id)
-                  telega-describe-chat-join-requests--processing)))
+         (nrequests (plist-get join-requests :total_count)))
     (telega-ins-describe-item "Chat"
       (telega-ins--msg-sender chat
         :with-brackets-p t
@@ -1551,24 +1508,20 @@ APPROVE-P is non-nil to approve the requests and nil to decline them."
 
       (telega-ins-describe-item (telega-i18n "lng_manage_peer_requests")
         (telega-ins-fmt "%d" nrequests)
-        (cond (processing-p
-               (telega-ins " ")
-               (telega-ins--with-face 'telega-shadow
-                 (telega-ins-i18n "telega_group_requests_processing")))
-              ((> nrequests 1)
-               (telega-ins " ")
-               (telega-ins--ui-button
-                   (telega-i18n "telega_group_requests_approve_all")
-                 'action (lambda (_button)
-                           (telega-describe-chat-join-requests--process-all
-                            chat nrequests t)))
-               (telega-ins " ")
-               (telega-ins--text-button
-                   (telega-i18n "telega_group_requests_decline_all")
-                 'face 'telega-link
-                 'action (lambda (_button)
-                           (telega-describe-chat-join-requests--process-all
-                            chat nrequests nil))))))
+        (when (> nrequests 1)
+          (telega-ins " ")
+          (telega-ins--ui-button
+              (telega-i18n "telega_group_requests_approve_all")
+            'action (lambda (_button)
+                      (telega-describe-chat-join-requests--process-all
+                       chat nrequests t)))
+          (telega-ins " ")
+          (telega-ins--text-button
+              (telega-i18n "telega_group_requests_decline_all")
+            'face 'telega-link
+            'action (lambda (_button)
+                      (telega-describe-chat-join-requests--process-all
+                       chat nrequests nil)))))
       (seq-doseq (jr (plist-get join-requests :requests))
         (let ((user (telega-user-get (plist-get jr :user_id))))
           (telega-ins--raw-button
@@ -1581,22 +1534,20 @@ APPROVE-P is non-nil to approve the requests and nil to decline them."
                                 (telega-ins--date (plist-get jr :date))))
             (telega-ins--help-message
              (telega-ins (telega-tl-str jr :bio))))
-          (unless processing-p
-            (telega-ins--line-wrap-prefix "  "
-              (telega-ins--ui-button (telega-i18n "lng_group_requests_add")
-                'action (lambda (_button)
-                          (telega--processChatJoinRequest chat user t
-                            (lambda (_reply)
-                              (telega-describe-chat-join-requests chat)))))
-              (telega-ins " ")
-              (telega-ins--text-button
-                  (telega-i18n "lng_group_requests_dismiss")
-                'face 'telega-link
-                'action (lambda (_button)
-                          (telega--processChatJoinRequest chat user nil
-                            (lambda (_reply)
-                              (telega-describe-chat-join-requests chat)))))
-              (telega-ins "\n")))
+          (telega-ins--line-wrap-prefix "  "
+            (telega-ins--ui-button (telega-i18n "lng_group_requests_add")
+              'action (lambda (_button)
+                        (telega--processChatJoinRequest chat user t
+                          (lambda (_reply)
+                            (telega-describe-chat-join-requests chat)))))
+            (telega-ins " ")
+            (telega-ins--text-button (telega-i18n "lng_group_requests_dismiss")
+              'face 'telega-link
+              'action (lambda (_button)
+                        (telega--processChatJoinRequest chat user nil
+                          (lambda (_reply)
+                            (telega-describe-chat-join-requests chat)))))
+            (telega-ins "\n"))
           ))
       )))
 

--- a/telega-info.el
+++ b/telega-info.el
@@ -1474,10 +1474,72 @@ SETTING is one of `show-status', `allow-chat-invites' or `allow-calls'."
     (setq telega--help-win-inserter #'telega-describe-quick-replies--inserter)
     ))
 
+(defvar-local telega-describe-chat-join-requests--processing nil
+  "Identifiers of chats with join requests currently being processed.")
+
+(defun telega-describe-chat-join-requests--process-all-next
+    (chat previous-count approve-p buffer)
+  "Process the next batch of CHAT join requests.
+PREVIOUS-COUNT is the number before this batch, APPROVE-P specifies
+the action, and BUFFER is the join requests buffer."
+  (let* ((chat-id (plist-get chat :id))
+         (finish
+          (lambda (&optional error-message)
+            (when (buffer-live-p buffer)
+              (with-current-buffer buffer
+                (setq telega-describe-chat-join-requests--processing
+                      (delete chat-id
+                              telega-describe-chat-join-requests--processing)))
+              (telega-describe-chat-join-requests chat))
+            (when error-message
+              (message "telega: %s" error-message)))))
+    (telega--processChatJoinRequests chat approve-p
+      (lambda (reply)
+        (if (telega--tl-error-p reply)
+            (funcall finish (plist-get reply :message))
+          (telega--getChatJoinRequests chat :limit 1
+            :callback
+            (lambda (join-requests)
+              (if (telega--tl-error-p join-requests)
+                  (funcall finish (plist-get join-requests :message))
+                (let ((remaining (plist-get join-requests :total_count)))
+                  (if (or (zerop remaining)
+                          (>= remaining previous-count))
+                      (funcall finish)
+                    (telega-describe-chat-join-requests--process-all-next
+                     chat remaining approve-p buffer)))))))))))
+
+(defun telega-describe-chat-join-requests--process-all
+    (chat nrequests approve-p)
+  "Process all NREQUESTS pending join requests in CHAT.
+APPROVE-P is non-nil to approve the requests and nil to decline them."
+  (let ((chat-id (plist-get chat :id)))
+    (if (member chat-id telega-describe-chat-join-requests--processing)
+        (message "%s" (telega-i18n "telega_group_requests_processing"))
+      (when (yes-or-no-p
+             (concat
+              (unless approve-p
+                (concat (telega-i18n "telega_action_cant_undone") "\n"))
+              (telega-i18n
+                  (if approve-p
+                      "telega_query_group_requests_approve_all"
+                    "telega_query_group_requests_decline_all")
+                :count nrequests
+                :title (telega-chat-title chat))
+              " "))
+        (push chat-id telega-describe-chat-join-requests--processing)
+        (let ((buffer (current-buffer)))
+          (telega-describe-chat-join-requests chat)
+          (telega-describe-chat-join-requests--process-all-next
+           chat nrequests approve-p buffer))))))
+
 (defun telega-describe-chat-join-requests--inserter (chat)
   "Inserter for the CHAT's pending join requests."
   (let* ((join-requests (telega--getChatJoinRequests chat))
-         (nrequests (plist-get join-requests :total_count)))
+         (nrequests (plist-get join-requests :total_count))
+         (processing-p
+          (member (plist-get chat :id)
+                  telega-describe-chat-join-requests--processing)))
     (telega-ins-describe-item "Chat"
       (telega-ins--msg-sender chat
         :with-brackets-p t
@@ -1488,7 +1550,25 @@ SETTING is one of `show-status', `allow-chat-invites' or `allow-calls'."
           (telega-ins-i18n "lng_group_requests_none"))
 
       (telega-ins-describe-item (telega-i18n "lng_manage_peer_requests")
-        (telega-ins-fmt "%d" nrequests))
+        (telega-ins-fmt "%d" nrequests)
+        (cond (processing-p
+               (telega-ins " ")
+               (telega-ins--with-face 'telega-shadow
+                 (telega-ins-i18n "telega_group_requests_processing")))
+              ((> nrequests 1)
+               (telega-ins " ")
+               (telega-ins--ui-button
+                   (telega-i18n "telega_group_requests_approve_all")
+                 'action (lambda (_button)
+                           (telega-describe-chat-join-requests--process-all
+                            chat nrequests t)))
+               (telega-ins " ")
+               (telega-ins--text-button
+                   (telega-i18n "telega_group_requests_decline_all")
+                 'face 'telega-link
+                 'action (lambda (_button)
+                           (telega-describe-chat-join-requests--process-all
+                            chat nrequests nil))))))
       (seq-doseq (jr (plist-get join-requests :requests))
         (let ((user (telega-user-get (plist-get jr :user_id))))
           (telega-ins--raw-button
@@ -1501,31 +1581,35 @@ SETTING is one of `show-status', `allow-chat-invites' or `allow-calls'."
                                 (telega-ins--date (plist-get jr :date))))
             (telega-ins--help-message
              (telega-ins (telega-tl-str jr :bio))))
-          (telega-ins--line-wrap-prefix "  "
-            (telega-ins--ui-button (telega-i18n "lng_group_requests_add")
-              'action (lambda (_button)
-                        (telega--processChatJoinRequest chat user t
-                          (lambda (_reply)
-                            (telega-describe-chat-join-requests chat)))))
-            (telega-ins " ")
-            (telega-ins--text-button (telega-i18n "lng_group_requests_dismiss")
-              'face 'telega-link
-              'action (lambda (_button)
-                        (telega--processChatJoinRequest chat user nil
-                          (lambda (_reply)
-                            (telega-describe-chat-join-requests chat)))))
-            (telega-ins "\n"))
+          (unless processing-p
+            (telega-ins--line-wrap-prefix "  "
+              (telega-ins--ui-button (telega-i18n "lng_group_requests_add")
+                'action (lambda (_button)
+                          (telega--processChatJoinRequest chat user t
+                            (lambda (_reply)
+                              (telega-describe-chat-join-requests chat)))))
+              (telega-ins " ")
+              (telega-ins--text-button
+                  (telega-i18n "lng_group_requests_dismiss")
+                'face 'telega-link
+                'action (lambda (_button)
+                          (telega--processChatJoinRequest chat user nil
+                            (lambda (_reply)
+                              (telega-describe-chat-join-requests chat)))))
+              (telega-ins "\n")))
           ))
       )))
 
-(defun telega-describe-chat-join-requests (chat)
-  "Describe list of pending requests."
+(defun telega-describe-chat-join-requests (chat &optional show-p)
+  "Describe list of pending requests.
+When SHOW-P is non-nil, display the join requests buffer even when
+this function is called non-interactively."
   (interactive
    (list (telega-completing-read-chat
           "Chat: " (telega-filter-chats (telega-chats-list)
                      '(prop :pending_join_requests)))))
 
-  (if (called-interactively-p 'interactive)
+  (if (or show-p (called-interactively-p 'interactive))
       (let ((help-window-select t))
         (with-telega-help-win "*Telega Join Requests*"
           (telega-describe-chat-join-requests--inserter chat)))

--- a/telega-ins.el
+++ b/telega-ins.el
@@ -54,7 +54,8 @@
 (declare-function telega-chat-admin-get "telega-chat" (chat user))
 
 (declare-function telega--full-info "telega-info" (tlobj &optional _callback))
-(declare-function telega-describe-chat-join-requests "telega-info" (chat))
+(declare-function telega-describe-chat-join-requests
+                  "telega-info" (chat &optional show-p))
 (declare-function telega-topic-button-action "telega-root" (chat-topic))
 
 (defun telega-ins--text-button (label &rest props)
@@ -4890,22 +4891,29 @@ Return non-nil if restrictions has been inserted."
               )
         t))))
 
-(defun telega-ins--chat-pending-join-requests (chat &optional jr-info)
-  "Inserter for CHAT's pending join requests"
+(defun telega-ins--chat-pending-join-requests
+    (chat &optional jr-info with-title-p)
+  "Inserter for CHAT's pending join requests.
+Use JR-INFO instead of CHAT's cached join request information when
+it is non-nil.  If WITH-TITLE-P is non-nil, also insert the join
+requests title as part of the button."
   (unless jr-info
     (setq jr-info (plist-get chat :pending_join_requests)))
   (when jr-info
-    (seq-doseq (user-id (plist-get jr-info :user_ids))
-      (telega-ins--image
-       (telega-msg-sender-avatar-image-one-line (telega-user-get user-id))))
-    (telega-ins " ")
-    (telega-ins--text-button
+    (telega-ins--raw-button
+        (list 'face 'telega-link
+              'follow-link t
+              'action (lambda (_button)
+                        (telega-describe-chat-join-requests chat 'show)))
+      (when with-title-p
+        (telega-ins (telega-i18n "lng_manage_peer_requests") ": "))
+      (seq-doseq (user-id (plist-get jr-info :user_ids))
+        (telega-ins--image
+         (telega-msg-sender-avatar-image-one-line (telega-user-get user-id))))
+      (telega-ins " ")
+      (telega-ins
         (telega-i18n "lng_group_requests_pending"
-          :count (plist-get jr-info :total_count))
-      'face 'telega-link
-      'action (lambda (_button)
-                (funcall-interactively
-                 #'telega-describe-chat-join-requests chat)))
+          :count (plist-get jr-info :total_count))))
     t))
 
 (defun telega-ins--chat-join-button (chat &optional bot-start-param)

--- a/telega-tdlib.el
+++ b/telega-tdlib.el
@@ -3768,6 +3768,16 @@ Use quickReplyMessage.can_be_edited to check whether a message can be edited."
          :approve (if approve-p t :false))
    callback))
 
+(defun telega--processChatJoinRequests (chat approve-p &optional callback)
+  "Handle all pending join requests in CHAT."
+  (declare (indent 2))
+  (telega-server--send-or-call
+   (list :@type "processChatJoinRequests"
+         :chat_id (plist-get chat :id)
+         :invite_link ""
+         :approve (if approve-p t :false))
+   callback))
+
 (defun telega--searchChatAffiliateProgram (username referrer &optional callback)
   "Searche a chat with an affiliate program."
   (declare (indent 2))


### PR DESCRIPTION
## Summary

- make the pending join-request footer entry one actionable button, so both mouse clicks and `RET` open the join-request view
- add **Approve All** and **Decline All** actions with confirmation
- add a thin wrapper for TDLib's `processChatJoinRequests`
- add English and Chinese UI strings

Each bulk action invokes `processChatJoinRequests` once, following TDLib's documented all-pending-requests semantics, and refreshes the join-request view when the call completes.

## Tests

- `make test` — 19/19 Emacs tests and 23/23 server tests pass
- verified with a mocked callback that one bulk action makes exactly one `processChatJoinRequests` call and no follow-up query
- `git diff --check` and plist/parenthesis validation pass
