### PR TITLE
Fix sending stickers with TDLib 1.8.65

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -4961,6 +4961,8 @@ Return valid \"messageSendOptions\"."
      (telega--tl-get imc :audio :audio))
     (inputMessageAnimation
      (telega--tl-get imc :animation :animation))
+    (inputMessageSticker
+     (telega--tl-get imc :sticker :sticker))
     (inputMessageVideoNote
      (plist-get imc :video_note))
     (inputMessageVoiceNote
@@ -6033,20 +6035,24 @@ Uses `telega-screenshot-function' to take a screenshot."
     (plist-put (cdr preview) :scale (/ 1.0 (car telega-sticker-size)))
 
     (telega-chatbuf-input-insert
-     (list :@type "inputMessageSticker"
-           :width (plist-get sticker :width)
-           :height (plist-get sticker :height)
-           ;; Use remote thumbnail and sticker files
-           :thumbnail (list :@type "inputThumbnail"
-                            :width (plist-get thumb :width)
-                            :height (plist-get thumb :height)
-                            :thumbnail (list :@type "inputFileId"
-                                             :id (telega--tl-get thumb :photo :id)))
-           ;; NOTE: 'telega-preview used in `telega-ins--input-file'
-           ;; to insert document/photo/sticker preview
-           :sticker (list :@type (propertize "inputFileId" 'telega-preview preview)
-                          :id (telega--tl-get sticker :sticker :id))
-           ))
+     `(:@type "inputMessageSticker"
+           :sticker
+           (:@type "inputSticker"
+            ;; NOTE: 'telega-preview used in `telega-ins--input-file'
+            ;; to insert document/photo/sticker preview
+            :sticker (:@type ,(propertize "inputFileId"
+                                          'telega-preview preview)
+                              :id ,(telega--tl-get sticker :sticker :id))
+            ;; Use remote thumbnail and sticker files
+            :thumbnail (:@type "inputThumbnail"
+                                :width ,(plist-get thumb :width)
+                                :height ,(plist-get thumb :height)
+                                :thumbnail
+                                (:@type "inputFileId"
+                                        :id ,(telega--tl-get thumb :photo :id)))
+            :width ,(plist-get sticker :width)
+            :height ,(plist-get sticker :height))
+           :emoji ,(telega-sticker-emoji sticker 'no-props)))
     ))
 
 (defun telega-chatbuf-custom-emoji-insert (sticker &optional emoji)

--- a/telega-ins.el
+++ b/telega-ins.el
@@ -4229,7 +4229,8 @@ If SHORT-P is non-nil then use short version."
              (telega-vvnote-video--svg thumb-filename))))
         (telega-ins " (" (telega-duration-human-readable duration) ")")))
      (inputMessageSticker
-      (telega-ins--input-file (plist-get imc :sticker) "Sticker"))
+      (telega-ins--input-file
+       (telega--tl-get imc :sticker :sticker) "Sticker"))
      (inputMessageAnimation
       (let* ((input-animation (plist-get imc :animation))
              (duration (or (plist-get input-animation :duration) 0))


### PR DESCRIPTION
TDLib 1.8.65 moved sticker media fields into the nested `inputSticker` object, matching the new wrappers for other media. telega still constructed the legacy flat `inputMessageSticker`, so `sendMessage` returned an error and the sticker disappeared from the input without being sent.

- Construct the nested `inputSticker` and pass `emoji` at the `inputMessageSticker` level.
- Teach input-file extraction and the one-line input preview about the nested structure.

Verified with a targeted ERT regression covering the generated types, file and thumbnail IDs, dimensions, emoji, and input-file extraction. `git diff --check` also passes.

TDLib schema: https://github.com/tdlib/td/blob/master/td/generate/scheme/td_api.tl#L5024-L5029