### PR TITLE
Scale box button brackets to the content height

### DIFF
--- a/telega-core.el
+++ b/telega-core.el
@@ -2147,14 +2147,30 @@ Return what BODY returns."
   (declare (indent 1))
   (let ((style-sym (gensym "style"))
         (left-bracket-sym (gensym "left-bracket"))
-        (right-bracket-sym (gensym "right-bracket")))
-    `(let ((,style-sym ,style))
+        (right-bracket-sym (gensym "right-bracket"))
+        (content-height-p-sym (gensym "content-height-p"))
+        (left-start-sym (gensym "left-start"))
+        (body-start-sym (gensym "body-start"))
+        (body-string-sym (gensym "body-string")))
+    `(let* ((,style-sym ,style)
+            (,left-bracket-sym
+             (telega-box-button--style-get ,style-sym :left-bracket))
+            (,right-bracket-sym
+             (telega-box-button--style-get ,style-sym :right-bracket))
+            (,content-height-p-sym
+             (or (and (consp ,left-bracket-sym)
+                      (eq (plist-get (cdr ,left-bracket-sym) :height)
+                          'content))
+                 (and (consp ,right-bracket-sym)
+                      (eq (plist-get (cdr ,right-bracket-sym) :height)
+                          'content))))
+            ,left-start-sym ,body-string-sym)
        (telega-ins--with-face
            (telega-box-button--style-get ,style-sym :passive-face)
 
          ;; Left bracket
-         (when-let ((,left-bracket-sym 
-                     (telega-box-button--style-get ,style-sym :left-bracket)))
+         (setq ,left-start-sym (point))
+         (when ,left-bracket-sym
            (if (stringp ,left-bracket-sym)
                (telega-ins ,left-bracket-sym)
              (telega-ins--image
@@ -2162,19 +2178,36 @@ Return what BODY returns."
                ,style-sym :left-bracket ,left-bracket-sym))))
 
          ;; Button body
-         (telega-ins--with-face (telega-box-button--body-face ,style-sym)
-           (telega-ins (telega-box-button--style-get ,style-sym :prefix))
-           ,@body
-           (telega-ins (telega-box-button--style-get ,style-sym :suffix)))
+         (let ((,body-start-sym (point)))
+           (telega-ins--with-face (telega-box-button--body-face ,style-sym)
+             (telega-ins (telega-box-button--style-get ,style-sym :prefix))
+             ,@body
+             (telega-ins (telega-box-button--style-get ,style-sym :suffix)))
+
+           (when ,content-height-p-sym
+             (setq ,body-string-sym
+                   (concat (buffer-substring
+                            (line-beginning-position) ,left-start-sym)
+                           (buffer-substring ,body-start-sym (point)))))
+
+           ;; Adjust already inserted left bracket to content height
+           (when (and ,content-height-p-sym
+                      ,left-start-sym
+                      (get-text-property ,left-start-sym 'display))
+             (put-text-property
+              ,left-start-sym ,body-start-sym 'display
+              (telega-box-button--bracket-image
+               ,style-sym :left-bracket ,left-bracket-sym
+               ,body-string-sym))))
 
          ;; Right bracket
-         (when-let ((,right-bracket-sym
-                     (telega-box-button--style-get ,style-sym :right-bracket)))
+         (when ,right-bracket-sym
            (if (stringp ,right-bracket-sym)
                (telega-ins ,right-bracket-sym)
              (telega-ins--image
               (telega-box-button--bracket-image
-               ,style-sym :right-bracket ,right-bracket-sym))))
+               ,style-sym :right-bracket ,right-bracket-sym
+               ,body-string-sym))))
          t))))
 
 (defmacro telega-ins--box-button2 (label style &rest button-props)

--- a/telega-customize.el
+++ b/telega-customize.el
@@ -289,8 +289,8 @@ performance might suffer."
      )
 
     (reaction
-     :left-bracket ("(" :width 0.75 :rx 0.5)
-     :right-bracket (")" :width 1.0 :rx 0.5 :margin 0.25)
+     :left-bracket ("(" :width 0.75 :height content :rx 0.5)
+     :right-bracket (")" :width 1.0 :height content :rx 0.5 :margin 0.25)
      :passive-face telega-reaction
      :outline-width 1
      :outline-color (face-background 'default))
@@ -321,6 +321,8 @@ performance might suffer."
 
     (telega-ui
      :inherit default
+     :left-bracket ("[" :width 0.5 :height content :rx 0.25)
+     :right-bracket ("]" :width 0.5 :height content :rx 0.25)
      :passive-face telega-box-button-ui-passive
      :active-face telega-box-button-ui-active
      :outline-width 0.1
@@ -333,8 +335,8 @@ performance might suffer."
 
     (iv
      :inherit telega-ui
-     :left-bracket ("[" :width 1 :rx 0)
-     :right-bracket ("]" :width 1 :rx 0)
+     :left-bracket ("[" :width 1 :height content :rx 0)
+     :right-bracket ("]" :width 1 :height content :rx 0)
      :prefix "  "
      :suffix "  ")
     (comments
@@ -343,8 +345,8 @@ performance might suffer."
 
     ;; Keyboard buttons with TL ButtonStyle
     (keyboard-default
-     :left-bracket ("[" :width 1.0 :rx 0.15 :margin 0)
-     :right-bracket ("]" :width 1.0 :rx 0.15 :margin 0)
+     :left-bracket ("[" :width 1.0 :height content :rx 0.15 :margin 0)
+     :right-bracket ("]" :width 1.0 :height content :rx 0.15 :margin 0)
      :passive-face telega-box-button-default-passive
      :active-face telega-box-button-default-active
      :col-delimiter " "

--- a/telega-util.el
+++ b/telega-util.el
@@ -2519,6 +2519,7 @@ the symbol `content' to use rendered line metrics of CONTENT."
             (let ((image (telega-svg-image svg
                            :scale 1.0
                            :height (telega-ch-height height)
+                           :background nil
                            :telega-text (car bracket-spec)
                            :ascent ascent)))
               (telega-emoji--image-cache-put cacheprop 1 image)

--- a/telega-util.el
+++ b/telega-util.el
@@ -2394,9 +2394,50 @@ integer values, then absolute value in pixels is used."
       :mask 'heuristic
       :telega-text "()")))
 
+(defun telega-box-button--content-metrics (content)
+  "Return image metrics as (HEIGHT . ASCENT) cons for the CONTENT.
+HEIGHT is in characters and ASCENT is a percentage.
+Metrics are measured from real CONTENT rendering, so emoji
+compositions, embedded images and raised text are all taken into
+account."
+  (when (and content (not (string-empty-p content))
+             (fboundp 'buffer-text-pixel-size))
+    (when-let* ((window
+                 (or (get-buffer-window nil t)
+                     (when-let ((frame (telega-x-frame)))
+                       (frame-selected-window frame))))
+                ((display-graphic-p (window-frame window)))
+                (char-height (telega-chars-xheight 1))
+                ((> char-height 0)))
+      (with-temp-buffer
+        (setq-local truncate-lines t)
+        (insert content)
+        ;; Anchor char in the default face, because button resides on
+        ;; a screen line also having default face glyphs, and screen
+        ;; line height is max(ascents) + max(descents)
+        (insert (propertize "x" 'face 'default))
+        (when-let* ((h1 (cdr (buffer-text-pixel-size
+                              (current-buffer) window t)))
+                    ((> h1 0)))
+          ;; Baseline probe: appending H1 pixels high `:ascent 100'
+          ;; space grows the line by exactly the line's descent
+          (insert (propertize " " 'display `(space :height (,h1) :ascent 100)))
+          (let* ((h2 (cdr (buffer-text-pixel-size
+                           (current-buffer) window t)))
+                 (ascent (- (* 2 h1) h2)))
+            ;; NOTE: `ceiling' is essential, image ascent is truncated
+            ;; on display as floor(percent * height / 100), so
+            ;; `round'ing down here would place the image 1px lower,
+            ;; with content peeking out above the button
+            (cons (/ (float h1) char-height)
+                  (max 0 (min 100 (ceiling (* 100 (/ (float ascent) h1))))))))))))
+
 (defun telega-box-button--bracket-image (style bracket-prop
-                                               &optional bracket-spec)
-  "Generate bracket image for the STYLE and BRACKET-PROP."
+                                               &optional bracket-spec content)
+  "Generate bracket image for the STYLE and BRACKET-PROP.
+BRACKET-SPEC is a cons (TEXT . PROPS).  The `:height' property
+in PROPS specifies proportional image height in characters, or
+the symbol `content' to use rendered line metrics of CONTENT."
   (when-let* ((bracket-spec
                (or bracket-spec
                    (telega-box-button--style-get style bracket-prop)))
@@ -2408,17 +2449,30 @@ integer values, then absolute value in pixels is used."
                            (face-background 'default)))
            (outline-color (telega-box-button--style-outline-color style))
            (outline-width (telega-box-button--style-outline-width style))
+           (content-metrics
+            (when (eq (plist-get bracket-props :height) 'content)
+              (telega-box-button--content-metrics content)))
+           (height (let ((hval (plist-get bracket-props :height)))
+                     (cond ((numberp hval) hval)
+                           ((eq hval 'content)
+                            (or (car content-metrics) 1))
+                           (t 1))))
+           (ascent (or (cdr content-metrics) 'center))
            (left-p (eq bracket-prop :left-bracket))
            (icon-symbol (unless left-p
                           (telega-box-button--style-get style :icon-symbol)))
-           (cacheprop (format "button-bracket-%S-%S-%S-%S-%S-%S"
+           (cacheprop (format "button-bracket-%S-%S-%S-%S-%S-%S-%S-%S"
                               bracket-prop bracket-spec
                               fill-color outline-color
-                              outline-width icon-symbol)))
+                              outline-width height ascent icon-symbol)))
       (or (and (not (plist-get (cdr bracket-spec) :no-cache))
                (telega-emoji--image-cache-get cacheprop 1))
           (let* ((w (round (telega-chars-xwidth
                             (or (plist-get bracket-props :width) 1))))
+                 ;; NOTE: viewport is 1 char high on purpose, svg is
+                 ;; proportionally scaled up to the displayed
+                 ;; `:height', so bracket caps keep their shape,
+                 ;; growing wider for taller content
                  (h (telega-chars-xheight 1))
                  (svg (telega-svg-create w h))
                  (mask (dom-node 'mask `((id . "hole"))))
@@ -2427,16 +2481,19 @@ integer values, then absolute value in pixels is used."
                  (round-fraction
                   (or (plist-get bracket-props :rx) 0.25))
                  (xpos (round (* w (if left-p pos-fraction (- 1 pos-fraction)))))
-                 (sw (or outline-width 0))
+                 ;; NOTE: proportional scaling is compensated in the
+                 ;; outline width, so on display outline is exactly
+                 ;; `outline-width' pixels, matching horizontal
+                 ;; outline lines drawn in the button body by the
+                 ;; `:box' of the `telega-box-button--body-face'
+                 (sw (/ (or outline-width 0) (float height)))
                  (sw2 (/ sw 2.0)))
             (svg--def svg mask)
             (svg-rectangle mask 0 0 w h :fill "white")
-            (svg-rectangle mask (if left-p (+ xpos sw2) (- 0 w sw2)) sw2
-                           (if left-p (+ w w) (+ w xpos)) (- h sw)
+            (svg-rectangle mask (if left-p (+ xpos sw) (- 0 w sw)) sw
+                           (if left-p (+ w w) (+ w xpos)) (- h (* 2 sw))
                            :rx (round (* h round-fraction))
-                           :fill "black"
-                           :stroke-width sw
-                           :stroke-color "black")
+                           :fill "black")
 
             (svg-rectangle svg 0 0 w h
                            :fill (telega-color-name-as-hex-2digits fill-color)
@@ -2461,9 +2518,9 @@ integer values, then absolute value in pixels is used."
 
             (let ((image (telega-svg-image svg
                            :scale 1.0
-                           :height (telega-ch-height 1)
+                           :height (telega-ch-height height)
                            :telega-text (car bracket-spec)
-                           :ascent 'center)))
+                           :ascent ascent)))
               (telega-emoji--image-cache-put cacheprop 1 image)
               image))))))
 

--- a/test.el
+++ b/test.el
@@ -86,7 +86,7 @@ Have Stoploss 690 Satoshi." :entities []))))
          :name (:@type "chatFolderName" :text (:@type "formattedText" :text "Emacs" :entities []))
          :icon (list :@type "chatFolderIcon" :name ""))
         ("ðŸ˜¹ðŸ˜¹ðŸ˜¹" :@type "chatFolderInfo" :id 3
-         :name (:@type "chatFolderName" :text (:@type "formattedText" :text #("í ½í¸¹í ½í¸¹í ½í¸¹" 0 2 (telega-emoji-p t telega-display "ðŸ˜¹") 2 4 (telega-emoji-p t telega-display "ðŸ˜¹") 4 6 (telega-emoji-p t telega-display "ðŸ˜¹")) :entities []) :animate_custom_emoji t)
+         :name (:@type "chatFolderName" :text (:@type "formattedText" :text #("ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½" 0 2 (telega-emoji-p t telega-display "ðŸ˜¹") 2 4 (telega-emoji-p t telega-display "ðŸ˜¹") 4 6 (telega-emoji-p t telega-display "ðŸ˜¹")) :entities []) :animate_custom_emoji t)
          :icon (list :@type "chatFolderIcon" :name ""))))
 
 
@@ -281,6 +281,114 @@ Have Stoploss 690 Satoshi." :entities []))))
         (should target)
         (button-activate button)
         (should (= (point) target))))))
+
+(ert-deftest telega-box-button-content-metrics ()
+  (let (line-heights)
+    (cl-letf (((symbol-function 'get-buffer-window)
+               (lambda (&rest _args) (selected-window)))
+              ((symbol-function 'telega-chars-xheight)
+               (lambda (n) (* n 14)))
+              ((symbol-function 'display-graphic-p)
+               (lambda (&optional _display) t))
+              ;; First call measures the line height H1, second call
+              ;; measures H1 + line descent (the baseline probe)
+              ((symbol-function 'buffer-text-pixel-size)
+               (lambda (&rest _args) (cons 42 (pop line-heights)))))
+      ;; Plain text line: height 14, descent 2 -> ascent 12
+      (setq line-heights (list 14 16))
+      (should (equal (telega-box-button--content-metrics "A")
+                     (cons 1.0 86)))
+      ;; Line with emoji: height 20, descent 5 -> ascent 15
+      (setq line-heights (list 20 25))
+      (should (equal (telega-box-button--content-metrics (string ?A #xfe0f))
+                     (cons (/ 20.0 14) 75)))
+      ;; Ascent percentage must be `ceiling'ed: 18/23 = 78.26%, and
+      ;; display truncates floor(78 * 23 / 100) = 17px < 18px, placing
+      ;; the bracket 1px too low; 79% restores exact 18px
+      (setq line-heights (list 23 28))
+      (should (equal (telega-box-button--content-metrics (string ?A #xfe0f))
+                     (cons (/ 23.0 14) 79))))))
+
+(ert-deftest telega-box-button-content-height-inserter ()
+  (let ((calls 0)
+        body-point
+        (telega-use-images nil))
+    (with-temp-buffer
+      (telega-ins--with-style (telega-box-button-style 'reaction)
+        (cl-incf calls)
+        (setq body-point (point))
+        (telega-ins "x"))
+      (should (= calls 1))
+      (should (= body-point 2))
+      (should (equal (buffer-string) "(x)"))))
+
+  (let ((telega-use-images t)
+        measured-content)
+    (cl-letf (((symbol-function 'telega-ins--image)
+               (lambda (image &optional _slice-num &rest _props)
+                 (let ((start (point)))
+                   (telega-ins
+                    (plist-get (cdr image) :telega-text))
+                   (put-text-property start (point) 'display image))))
+              ((symbol-function 'telega-box-button--bracket-image)
+               (lambda (_style bracket-prop &optional _spec content)
+                 (when content
+                   (setq measured-content content))
+                 (list 'image
+                       :type 'svg
+                       :data ""
+                       :telega-text
+                       (if (eq bracket-prop :left-bracket) "(" ")")
+                       :height (if content 2 1)))))
+      (with-temp-buffer
+        (telega-ins "prefix ")
+        (let ((button-start (point)))
+          (telega-ins--with-style (telega-box-button-style 'reaction)
+            (telega-ins "x"))
+          (should (= (plist-get
+                      (cdr (get-text-property button-start 'display))
+                      :height)
+                     2)))
+        (should (= (plist-get
+                    (cdr (get-text-property (1- (point-max)) 'display))
+                    :height)
+                   2))
+        (should (string-prefix-p "prefix " measured-content))))))
+
+(ert-deftest telega-box-button-bracket-metrics ()
+  (cl-letf (((symbol-function 'telega-chars-xwidth)
+             (lambda (n) (* n 10)))
+            ((symbol-function 'telega-chars-xheight)
+             (lambda (n) (ceiling (* n 16))))
+            ((symbol-function 'telega-box-button--content-metrics)
+             (lambda (_content) '(1.5 . 80)))
+            ((symbol-function 'telega-emoji--image-cache-get)
+             (lambda (&rest _args) nil))
+            ((symbol-function 'telega-emoji--image-cache-put)
+             (lambda (_key _scale image) image)))
+    (let ((default-image
+           (telega-box-button--bracket-image
+            (telega-box-button-style 'default) :left-bracket)))
+      (should (equal (plist-get (cdr default-image) :height)
+                     (telega-ch-height 1)))
+      (should (eq (plist-get (cdr default-image) :ascent)
+                  'center))
+      ;; Viewport is always 1 char high; a larger displayed `:height'
+      ;; scales the bracket proportionally, preserving cap shape
+      (should (string-match-p
+               "<svg width=\"[^\"]+\" height=\"16\""
+               (plist-get (cdr default-image) :data)))
+      (dolist (style '(reaction telega-ui iv comments))
+        (let ((content-image
+               (telega-box-button--bracket-image
+                (telega-box-button-style style)
+                :left-bracket nil "emoji")))
+          (should (equal (plist-get (cdr content-image) :height)
+                         (telega-ch-height 1.5)))
+          (should (= (plist-get (cdr content-image) :ascent) 80))
+          (should (string-match-p
+                   "<svg width=\"[^\"]+\" height=\"16\""
+                   (plist-get (cdr content-image) :data))))))))
 
 (ert-deftest telega-org-formatting ()
   "Test org mode text formatting."


### PR DESCRIPTION
Box button brackets stay too short when emoji, CJK glyphs, embedded images or taller fonts increase the line height.

Add `:height content` to measure the styled line prefix and button body once, then share the height and baseline between both SVG brackets. Keep outlines aligned with the body and preserve transparent areas during highlighting.

Text-only rendering, unavailable metrics and multiline labels retain the fixed-size fallback. Mixed text and image brackets are supported.

Validation: 31 ERT tests pass. GUI checks cover CJK, emoji, font scaling and multiline fallback.

<details>
<summary>Before / after screenshots</summary>

### Before

<img width="180" height="60" alt="image" src="https://github.com/user-attachments/assets/350b2a5b-1c8c-4b21-b819-6f37f9ab4b4b" />

<img width="259" height="62" alt="image" src="https://github.com/user-attachments/assets/1476cbbd-cce1-4835-9a43-d75771a904c7" />

<img width="264" height="51" alt="image" src="https://github.com/user-attachments/assets/b6d1afa9-0f56-4ad3-b911-05cbc0f1888a" />

<img width="239" height="47" alt="image" src="https://github.com/user-attachments/assets/1b07b5f7-e1f5-4fde-925c-020e725cfd00" />

<img width="253" height="61" alt="image" src="https://github.com/user-attachments/assets/82913d5d-a0dd-4164-9d0d-277f3331c9a6" />

<img width="434" height="80" alt="image" src="https://github.com/user-attachments/assets/c7b22015-4d6b-44b7-b72b-5906a352475b" />

### After

<img width="232" height="74" alt="image" src="https://github.com/user-attachments/assets/9c3206ad-f7b8-4379-b080-5e4a8d17b49e" />

<img width="299" height="45" alt="image" src="https://github.com/user-attachments/assets/84d1560f-f473-49cb-8946-153af374dcd2" />

<img width="205" height="69" alt="image" src="https://github.com/user-attachments/assets/66d189f1-9bff-43af-9fdd-842d763b0c8f" />

<img width="279" height="65" alt="image" src="https://github.com/user-attachments/assets/c944a9cd-ac97-400a-b32d-25ad24f324d1" />

<img width="227" height="50" alt="image" src="https://github.com/user-attachments/assets/5e9c1488-4d43-4cb9-aa1a-87a86b475cf8" />

<img width="422" height="40" alt="image" src="https://github.com/user-attachments/assets/418c05d9-fec6-466e-bd30-7599c5352440" />

</details>
