### PR TITLE
Fix Instant View with TDLib 1.8.66

### DIFF
--- a/telega-core.el
+++ b/telega-core.el
@@ -1618,6 +1618,8 @@ Properties specified in PROPS are retained on
           (apply #'make-text-button beg end
                  :type button-type
                  :value value
+                 :telega-retain-props
+                 (telega-plist-map (lambda (prop _ignored) prop) props)
                  props)))
     (when-let ((add-sensor (plist-get props :telega-add-sensor-func)))
       (telega--change-text-property

--- a/telega-webpage.el
+++ b/telega-webpage.el
@@ -148,7 +148,7 @@ Keymap:
 
 (defun telega-webpage--ins-pb-details (pb)
   "Inserter for `pageBlockDetails' page block PB."
-  (let ((open-p (not (plist-get pb :is_closed))))
+  (let ((open-p (plist-get pb :is_open)))
     (telega-ins--with-face 'telega-shadow
       (telega-ins (telega-symbol (if open-p 'outline-open 'outline-close))
                   " "))
@@ -159,7 +159,7 @@ Keymap:
     (telega-ins "\n")
 
     (when open-p
-      (mapc 'telega-webpage--ins-pb (plist-get pb :page_blocks)))
+      (mapc 'telega-webpage--ins-pb (plist-get pb :blocks)))
     ))
 
 (defun telega-webpage-rticon--image (rt)
@@ -202,13 +202,17 @@ Keymap:
       (richTextAnchor
        (telega-webpage--add-anchor (telega-tl-str rt :name)))
       (richTextReference
-       ;; TDLib 1.6.2
-       (let ((ref-url (telega-tl-str rt :url)))
+       ;; TDLib 1.8.66
+       (telega-webpage--add-anchor (telega-tl-str rt :name))
+       (telega-webpage--ins-rt (plist-get rt :text)))
+      (richTextReferenceLink
+       ;; TDLib 1.8.66
+       (let ((ref-name (telega-tl-str rt :reference_name)))
          (telega-ins--raw-button
              (list 'action #'telega-button--action
-                   :help-echo (concat "Reference: " ref-url)
-                   :value ref-url
-                   :action #'telega-browse-url)
+                   :help-echo (concat "Reference: #" ref-name)
+                   :value ref-name
+                   :action #'telega-webpage-goto-anchor)
            (telega-ins--with-face 'telega-link
              (telega-webpage--ins-rt (plist-get rt :text))))))
       (richTextAnchorLink
@@ -420,7 +424,7 @@ Keymap:
             (telega-ins (telega-strip-newlines
                          (telega-ins--as-string
                           (mapc #'telega-webpage--ins-pb
-                                (plist-get pb :page_blocks)))))))))
+                                (plist-get pb :blocks)))))))))
       (pageBlockList
        (let ((telega-webpage-strip-nl t))
          (mapc 'telega-webpage--ins-pb (plist-get pb :items))))
@@ -490,14 +494,14 @@ Keymap:
       (pageBlockEmbeddedPost
        (telega-ins "<TODO: pageBlockEmbeddedPost>\n"))
       (pageBlockCollage
-       (mapc #'telega-webpage--ins-pb (plist-get pb :page_blocks))
+       (mapc #'telega-webpage--ins-pb (plist-get pb :blocks))
        (telega-webpage--ins-pb (plist-get pb :caption)))
       (pageBlockSlideshow
-       (let ((page-blocks (plist-get pb :page_blocks)))
-         (dotimes (n (length page-blocks))
+       (let ((blocks (plist-get pb :blocks)))
+         (dotimes (n (length blocks))
            (telega-ins-from-newline
-            (telega-webpage--ins-pb (aref page-blocks n))
-            (telega-ins-fmt "%d/%d\n" (1+ n) (length page-blocks)))))
+            (telega-webpage--ins-pb (aref blocks n))
+            (telega-ins-fmt "%d/%d\n" (1+ n) (length blocks)))))
        (telega-webpage--ins-pb (plist-get pb :caption)))
       (pageBlockChatLink
        (telega-ins--with-face 'telega-webpage-chat-link
@@ -516,8 +520,8 @@ Keymap:
        (telega-button--insert 'telega pb
          'action (lambda (button)
                    (let* ((val (button-get button :value))
-                          (new-val (plist-put val :is_closed
-                                              (not (plist-get val :is_closed)))))
+                          (new-val (plist-put val :is_open
+                                              (not (plist-get val :is_open)))))
                      (save-excursion
                        (telega-button--update-value button new-val))))
          :inserter #'telega-webpage--ins-pb-details
@@ -583,7 +587,7 @@ instant view for the URL."
 
   (with-telega-buffer-modify
     (erase-buffer)
-    (seq-doseq (iv-pb (plist-get telega-webpage--iv :page_blocks))
+    (seq-doseq (iv-pb (plist-get telega-webpage--iv :blocks))
       (telega-ins-from-newline
        (telega-webpage--ins-pb iv-pb)))
 

--- a/test.el
+++ b/test.el
@@ -200,6 +200,88 @@ Have Stoploss 690 Satoshi." :entities []))))
                  "test.domain.ru##[title~=\\[NSP\\]]:nth-ancestor(6)"))
   )
 
+(ert-deftest telega-webpage-tdlib-1.8.66-block-fields ()
+  (with-temp-buffer
+    (let ((telega-webpage-strip-nl t))
+      (telega-webpage--ins-pb
+       '(:@type "pageBlockListItem" :label "*"
+         :blocks [(:@type "pageBlockParagraph"
+                   :text (:@type "richTextPlain" :text "LIST"))]))
+      (telega-webpage--ins-pb
+       '(:@type "pageBlockCollage"
+         :blocks [(:@type "pageBlockParagraph"
+                   :text (:@type "richTextPlain" :text "COLLAGE"))]))
+      (telega-webpage--ins-pb
+       '(:@type "pageBlockSlideshow"
+         :blocks [(:@type "pageBlockParagraph"
+                   :text (:@type "richTextPlain" :text "SLIDE"))]))
+      (let ((rendered (buffer-substring-no-properties
+                       (point-min) (point-max))))
+        (dolist (expected '("LIST" "COLLAGE" "SLIDE"))
+          (should (string-match-p expected rendered)))))))
+
+(ert-deftest telega-webpage-tdlib-1.8.66-top-level-blocks ()
+  (let ((telega-webpage-history nil)
+        (telega-webpage-history--index 0))
+    (cl-letf (((symbol-function 'cursor-face-highlight-mode) #'ignore))
+      (save-window-excursion
+        (unwind-protect
+            (progn
+              (telega-webpage--instant-view
+               "https://example.com" "Example"
+               '(:@type "webPageInstantView"
+                 :blocks [(:@type "pageBlockParagraph"
+                           :text (:@type "richTextPlain"
+                                  :text "TOP-LEVEL-CONTENT"))]
+                 :view_count 0 :is_full t))
+              (with-current-buffer "*Telega Instant View*"
+                (should (string-match-p
+                         "TOP-LEVEL-CONTENT"
+                         (buffer-substring-no-properties
+                          (point-min) (point-max))))))
+          (when-let* ((iv-buffer (get-buffer "*Telega Instant View*")))
+            (kill-buffer iv-buffer)))))))
+
+(ert-deftest telega-webpage-details-toggle ()
+  (with-temp-buffer
+    (telega-webpage--ins-pb
+     '(:@type "pageBlockDetails" :is_open t
+       :header (:@type "richTextPlain" :text "DETAILS")
+       :blocks [(:@type "pageBlockParagraph"
+                 :text (:@type "richTextPlain" :text "OPEN"))]))
+    (let ((button (button-at (point-min))))
+      (should (plist-get (button-get button :value) :is_open))
+      (should (string-match-p "OPEN" (buffer-string)))
+
+      (button-activate button)
+      (setq button (button-at (point-min)))
+      (should-not (plist-get (button-get button :value) :is_open))
+      (should-not (string-match-p "OPEN" (buffer-string)))
+
+      (button-activate button)
+      (should (plist-get (button-get (button-at (point-min)) :value)
+                         :is_open))
+      (should (string-match-p "OPEN" (buffer-string))))))
+
+(ert-deftest telega-webpage-reference-link ()
+  (with-temp-buffer
+    (let ((telega-webpage--anchors nil))
+      (telega-webpage--ins-rt
+       '(:@type "richTexts"
+         :texts [(:@type "richTextReferenceLink"
+                  :text (:@type "richTextPlain" :text "JUMP")
+                  :reference_name "note"
+                  :url "https://example.com/#note")
+                 (:@type "richTextPlain" :text " ")
+                 (:@type "richTextReference" :name "note"
+                  :text (:@type "richTextPlain" :text "TARGET"))]))
+      (let ((button (button-at (point-min)))
+            (target (cdr (assoc "note" telega-webpage--anchors))))
+        (should button)
+        (should target)
+        (button-activate button)
+        (should (= (point) target))))))
+
 (ert-deftest telega-org-formatting ()
   "Test org mode text formatting."
   (should (equal (telega-markup-org-fmt "*bold*")


### PR DESCRIPTION
## Summary

Update the Instant View renderer for TDLib 1.8.66 schema changes.

- Read `blocks` instead of the removed `page_blocks` field from `webPageInstantView`, list items, collages, slideshows, and details blocks.
- Use the TDLib `is_open` state when rendering and toggling details blocks.
- Handle the new `richTextReference` target and `richTextReferenceLink` link types as in-page anchors.
- Restore automatic button property retention in `telega-button--insert`, matching its documented behavior and the implementation before 6ff8203. Without it, updating a details button drops its inserter/action and the first toggle fails with `Button :inserter is unset`.

TDLib changes:

- [Simplify PageBlock field names](https://github.com/tdlib/td/commit/4f3676d76ccc082354b5b0a5645cecad947dfa04)
- [Add td_api::richTextReferenceLink](https://github.com/tdlib/td/commit/d17125721bbaf95fe4dd5801f1837f3acf9e83d0)

## Root cause

The top-level `webPageInstantView` object now returns its content in `:blocks`, while `telega-webpage--instant-view` still looked up `:page_blocks`. The lookup therefore returned nil and produced an empty Instant View buffer. The same rename affected several nested PageBlock types.

## Tests

Added ERT coverage for:

- top-level Instant View blocks
- nested list, collage, and slideshow blocks
- repeated details close/reopen
- reference-link navigation

Full local suite: **23 tests passed, 0 unexpected**.