### PR TITLE
fix(completions): flatten bot command candidates

### DIFF
--- a/telega-completions.el
+++ b/telega-completions.el
@@ -445,7 +445,7 @@ If CALLBACK is non-nil, invoke it asynchronously with the candidate list."
     (if (telega-chatbuf-match-p '(type bot))
         (telega-completions--bot-commands-list
          (telega--tl-get full-info :bot_info :commands))
-      (mapcar (lambda (bot-commands)
+      (mapcan (lambda (bot-commands)
                 (telega-completions--bot-commands-list
                  (plist-get bot-commands :commands)
                  (telega-msg-sender-username


### PR DESCRIPTION
First of all, thank you for maintaining telega.el!

In group chats, bot command completion currently exposes only the first command of each bot. For example, given:

- `A`: `/start`, `/convert`, `/status`
- `B`: `/latest`

completion only offers `/start@A` and `/latest@B`. The remaining commands from `A` are missing.

## My Analysis

`telega-completions--bot-commands-list` returns a list of completion candidates for one bot. Using an outer `mapcar` therefore produces a nested list:

```elisp
(("/start@bot_a" "/convert@bot_a" "/status@bot_a")
 ("/latest@bot_b"))
```

Each inner list can be interpreted as an alist entry. So only its first element to be exposed as a candidate.

**Note**: The commands were previously flattened during the completion refactoring in #556, but the flattening was removed in a later restructuring.

## My Fix

Replace the outer `mapcar` with `mapcan`, producing a flat candidate list:

```elisp
("/start@bot_a"
 "/convert@bot_a"
 "/status@bot_a"
 "/latest@bot_b")
```