### PR TITLE
Implement resend-as-file for photos with invalid dimensions

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -3042,7 +3042,10 @@ If NEW-FOCUS-STATE is specified, then focus state is forced."
 
 (defun telega-chatbuf-msg--pp-inserter (msg)
   "Return message inserter for the pretty printer."
-  (cond ((telega-msg-match-p msg
+  (cond ((plist-get msg :telega-resend-as-file)
+         #'telega-ins--msg-sending-state-failed)
+
+        ((telega-msg-match-p msg
            `(and is-deleted
                  (chat ,telega-chat-show-deleted-messages-for)))
          #'telega-ins--message-deleted)
@@ -4439,6 +4442,13 @@ Return last inserted ewoc node."
 
        node))))
 
+(defun telega-chatbuf--delete-internal-message (msg)
+  "Delete internal telega message MSG from its chat buffer."
+  (cl-assert (telega-msg-internal-p msg))
+  (with-telega-chatbuf (telega-msg-chat msg)
+    (when-let* ((node (telega-ewoc--find-by-data telega-chatbuf--ewoc msg)))
+      (ewoc-delete telega-chatbuf--ewoc node))))
+
 (defun telega-chatbuf--prepend-messages (messages)
   "Insert MESSAGES at the beginning of the chat buffer.
 First message in MESSAGE will be first message at the beginning."
@@ -4968,6 +4978,25 @@ Return valid \"messageSendOptions\"."
     (inputMessageVoiceNote
      (plist-get imc :voice_note))))
 
+(defun telega-chatbuf--handle-photo-send-result (chat imc input-reply-to
+                                                      options result)
+  "Handle RESULT of sending photo IMC to CHAT."
+  (when (telega-msg-photo-limit-error-p result)
+    (with-telega-chatbuf chat
+      (telega-chatbuf--insert-messages
+       (list
+        (telega-msg-create-internal
+            chat (telega-fmt-text "")
+          :sending_state (list :@type "messageSendingStateFailed"
+                               :error result)
+          :telega-resend-as-file
+          (list :content (telega-msg--input-document
+                          (telega--tl-get imc :photo :photo)
+                          (plist-get imc :caption))
+                :reply-to input-reply-to
+                :options options)))
+       'append-new))))
+
 (defun telega-chatbuf-input-send (arg &optional preview-p)
   "Send chatbuf input to the chat.
 If called interactively, number of `\\[universal-argument]' before
@@ -5169,10 +5198,22 @@ use.  For example `C-u RET' will use
            ;; No-op, just delimits messages
            )
 
-          (t (telega--sendMessage
-              telega-chatbuf--chat imc replying-imr options
-              :callback (when preview-p #'telega-msg-preview--add)
-              :sync-p (not telega-chat-send-messages-async)))))))
+          (t
+           (let* ((photo-p (eq (telega--tl-type imc) 'inputMessagePhoto))
+                  (callback
+                   (cond (preview-p #'telega-msg-preview--add)
+                         ((and photo-p telega-chat-send-messages-async)
+                          (apply-partially
+                           #'telega-chatbuf--handle-photo-send-result
+                           telega-chatbuf--chat imc replying-imr options))))
+                  (result
+                   (telega--sendMessage
+                    telega-chatbuf--chat imc replying-imr options
+                    :callback callback
+                    :sync-p (not telega-chat-send-messages-async))))
+             (when (and photo-p (not callback))
+               (telega-chatbuf--handle-photo-send-result
+                telega-chatbuf--chat imc replying-imr options result))))))))
 
       ;; NOTE: Cancell all file upload ahead, initiated by
       ;; attachements in `send-imcs' See

--- a/telega-ins.el
+++ b/telega-ins.el
@@ -3906,22 +3906,14 @@ If SENDER is specified, use it instead of messageOrigin from FWD-INFO."
       (telega-ins--with-face 'error
         (telega-ins "Failed to send: "
                     (telega-tl-str (plist-get send-state :error) :message)))
-      (cond ((and (telega-msg-match-p msg '(type Photo))
-                  (equal (telega-tl-str (plist-get send-state :error) :message)
-                         "PHOTO_INVALID_DIMENSIONS"))
-             ;; NOTE: Resending as file will accomplish without errors
-             (when-let ((photofile
-                         (plist-get (cl-find "i" (telega--tl-get
-                                                  msg :content :photo :sizes)
-                                             :test #'equal
-                                             :key (telega--tl-prop :type))
-                                    :photo))
-                        (caption (telega--tl-get msg :content :caption)))
-               (telega-ins " ")
-               (telega-ins--ui-button "RESEND as file"
-                 'action (lambda (_button)
-                           (message "TODO: resend as file")))))
-            )
+      (when (and (or (plist-get msg :telega-resend-as-file)
+                     (telega-msg-match-p msg '(type Photo)))
+                 (telega-msg-photo-limit-error-p
+                  (plist-get send-state :error)))
+        ;; NOTE: Resending as file will accomplish without errors
+        (telega-ins " ")
+        (telega-ins--ui-button "RESEND as file"
+          :action #'telega-msg-resend-as-file))
       t)))
 
 (cl-defun telega-ins--message0 (msg &key no-header sender addon-header-inserter)

--- a/telega-msg.el
+++ b/telega-msg.el
@@ -50,6 +50,7 @@
 (declare-function telega-chat-title "telega-chat" (chat &optional fmt-type no-badges))
 (declare-function telega-chatbuf--node-by-msg-id "telega-chat" (msg-id))
 (declare-function telega-chatbuf--chat-update "telega-chat" (&rest dirtiness))
+(declare-function telega-chatbuf--delete-internal-message "telega-chat" (msg))
 (declare-function telega-chat--type "telega-chat" (chat))
 (declare-function telega-chatevent-log-filter "telega-chat" (&rest filters))
 (declare-function telega-chat--pop-to-buffer "telega-chat" (chat))
@@ -1683,6 +1684,55 @@ favorite message."
                           :count 1)))
               required-stars))))
     (telega--resendMessages (list msg) nil pay-stars)))
+
+(defun telega-msg-photo-limit-error-p (error)
+  "Return non-nil if ERROR denotes a photo limit error."
+  (when (equal (plist-get error :@type) "error")
+    (let ((error-message (telega-tl-str error :message)))
+      (or (equal error-message "PHOTO_INVALID_DIMENSIONS")
+          (and error-message
+               (string-match-p "too big for a photo" error-message))))))
+
+(defun telega-msg--input-document (input-file &optional caption)
+  "Return an input message document for INPUT-FILE and optional CAPTION."
+  `(:@type "inputMessageDocument"
+           :document (:@type "inputDocument"
+                             :document ,input-file
+                             :disable_content_type_detection t)
+           ,@(when caption
+               (list :caption caption))))
+
+(defun telega-msg-resend-as-file (msg)
+  "Resend failed photo message MSG as a file."
+  (let* ((resend-info (plist-get msg :telega-resend-as-file))
+         (imc
+          (or (plist-get resend-info :content)
+              (when-let* ((photofile
+                           (plist-get (cl-find
+                                       "i" (telega--tl-get
+                                            msg :content :photo :sizes)
+                                       :test #'equal
+                                       :key (telega--tl-prop :type))
+                                      :photo))
+                          (filename
+                           (telega-tl-str (plist-get photofile :local) :path)))
+                (telega-msg--input-document
+                 (list :@type "inputFileLocal" :path filename)
+                 (when-let* ((caption
+                              (telega--tl-get msg :content :caption)))
+                   (telega-fmt-text-desurrogate
+                    (copy-sequence caption))))))))
+    (when imc
+      (telega--sendMessage
+       (telega-msg-chat msg)
+       imc
+       (plist-get resend-info :reply-to)
+       (plist-get resend-info :options)
+       :callback (lambda (new-msg)
+                   (unless (telega--tl-error-p new-msg)
+                     (if resend-info
+                         (telega-chatbuf--delete-internal-message msg)
+                       (telega--deleteMessages (list msg)))))))))
 
 (defun telega-msg-save (msg &optional to-saved-messages-p)
   "Save messages's MSG media content to a file.


### PR DESCRIPTION
Complete the existing `RESEND as file` button for photo messages that fail with `PHOTO_INVALID_DIMENSIONS`.

The action sends the original file as a document, preserves its caption, and removes the failed photo only after TDLib creates the replacement message. Direct pre-send errors use the existing error handling.

Validation: 25 ERT tests passed, including button activation, emoji captions, and rejected resend requests with mocked TDLib calls. Byte compilation and `check-parens` passed on Emacs 32.0.50.
