### PR TITLE
Fix draft messages with TDLib 1.8.66

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -3541,7 +3541,7 @@ otherwise set draft only if chatbuf input is also draft."
          (goto-char telega-chatbuf--input-marker)
          (telega-ins--with-props '(:draft-input-p t)
            (telega-ins--fmt-text
-            (telega--tl-get draft-msg :input_message_text :text))))))))
+            (telega--tl-get draft-msg :content :text))))))))
 
 (defun telega-chatbuf--load-initial-history ()
   "Load initial history in the chatbuf."
@@ -6418,10 +6418,9 @@ FOCUS-OUT-P is non-nil if called when chatbuf's frame looses focus."
        telega-chatbuf--chat
        (list :@type "draftMessage"
              :reply_to (telega-chatbuf-replying-imr)
-             :input_message_text
-             (list :@type "inputMessageText"
-                   :text (telega-string-fmt-text
-                          (telega-chatbuf-input-string)))))))
+             :content (list :@type "draftMessageContentText"
+                            :text (telega-string-fmt-text
+                                   (telega-chatbuf-input-string)))))))
 
   (telega-chatbuf--history-state-set
    :newer-freezed

--- a/telega-ins.el
+++ b/telega-ins.el
@@ -2411,7 +2411,7 @@ Return number of done tasks."
              (telega-ins-from-newline
               (telega-ins--with-face 'telega-shadow
                 (telega-ins-i18n "telega_loading"))))
-            ((not full-p)
+            ((and msg (not full-p))
              (telega-ins-from-newline
               (telega-ins--text-button (telega-i18n "lng_stories_show_more")
                 'face 'telega-link
@@ -4148,9 +4148,11 @@ If SHORT-P is non-nil then use short version."
                   (plist-get tl-ttl :self_destruct_time))))))
 
 (defun telega-ins--input-content-one-line (imc)
-  "Insert input message's MSG content for one line usage."
+  "Insert input message content IMC for one line usage."
   (telega-ins--one-lined
    (cl-case (telega--tl-type imc)
+     (inputMessageText
+      (telega-ins--fmt-text (plist-get imc :text)))
      (inputMessageLocation
       (telega-ins--location (plist-get imc :location))
       (when (> (or (plist-get imc :live_period) 0) 0)
@@ -4345,6 +4347,24 @@ If SHORT-P is non-nil then use short version."
      (t
       (telega-ins-fmt "<TODO: %S>" (telega--tl-type imc)))
      ))
+  t)
+
+(defun telega-ins--draft-content-one-line (draft-content)
+  "Insert DRAFT-CONTENT for one line usage."
+  (let* ((content-type (telega--tl-type draft-content))
+         (imc-type (cl-case content-type
+                     (draftMessageContentText "inputMessageText")
+                     (draftMessageContentVoiceNote "inputMessageVoiceNote")
+                     (draftMessageContentVideoNote "inputMessageVideoNote"))))
+    (cond (imc-type
+           (let ((fake-imc (copy-sequence draft-content)))
+             (plist-put fake-imc :@type imc-type)
+             (telega-ins--input-content-one-line fake-imc)))
+          ((eq content-type 'draftMessageContentRichMessage)
+           (telega-ins--one-lined
+            (telega-ins--rich-message (plist-get draft-content :message))))
+          (t
+           (telega-ins-fmt "<TODO: %S>" content-type))))
   t)
 
 (defun telega-ins--content-media-thumbnail-one-line (msg &optional content)
@@ -4870,19 +4890,13 @@ If TOPIC is given, insert chat status for the TOPIC."
              (telega-ins--actions actions)))
 
           (draft-msg
-           (let ((draft-content (plist-get draft-msg :content)))
-           ;; (let ((inmsg (plist-get draft-msg :input_message_text)))
-           ;;   (cl-assert (eq (telega--tl-type inmsg) 'inputMessageText) nil
-           ;;              "tdlib states that draft must be `inputMessageText'")
-             (telega-ins--with-attrs (list :align 'left
-                                           :max max-width
-                                           :elide t)
-               (telega-ins--with-face 'error
-                 (telega-ins (telega-i18n "lng_from_draft") ": "))
-               (telega-ins "TODO draft msg")
-               ;; (telega-ins--one-lined
-               ;;  (telega-ins--fmt-text (plist-get inmsg :text)))
-               )))
+           (telega-ins--with-attrs (list :align 'left
+                                         :max max-width
+                                         :elide t)
+             (telega-ins--with-face 'error
+               (telega-ins (telega-i18n "lng_from_draft") ": "))
+             (telega-ins--draft-content-one-line
+              (plist-get draft-msg :content))))
 
           (last-msg
            (if (telega-msg-match-p last-msg 'ignored)


### PR DESCRIPTION
## Summary

- save and restore drafts with both draftMessage representations found in TDLib 1.8.66 snapshots
- replace the chat-list draft placeholder with the actual draft content
- support text, rich-message, voice-note, and video-note draft previews

Some TDLib 1.8.66 snapshots use draftMessage.content while later ones use draftMessage.input_message_text. Sending and reading both forms keeps telega compatible with either schema.

## Testing

- make compile with Emacs 32.0.50
- make test_el: 23/23 tests passed
- verified incomplete rich-message drafts do not create a button without a message target