### PR TITLE
Fix sending voice and video notes with TDLib 1.8.66

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -4964,9 +4964,9 @@ Return valid \"messageSendOptions\"."
     (inputMessageSticker
      (telega--tl-get imc :sticker :sticker))
     (inputMessageVideoNote
-     (plist-get imc :video_note))
+     (telega--tl-get imc :video_note :video_note))
     (inputMessageVoiceNote
-     (plist-get imc :voice_note))))
+     (telega--tl-get imc :voice_note :voice_note))))
 
 (defun telega-chatbuf-input-send (arg &optional preview-p)
   "Send chatbuf input to the chat.
@@ -5920,17 +5920,19 @@ record video notes."
          (i-filename (plist-get ifile :path))
          (frame1 (plist-get telega-vvnote-video--preview :first-frame)))
     (telega-chatbuf-input-insert
-     (nconc
-      (list :@type "inputMessageVideoNote"
-            :duration (round (telega-ffplay-get-duration i-filename))
-            :length 240
-            :video_note ifile)
-      (when frame1
-        `(:thumbnail
-          (:@type "inputThumbnail"
-                  :thumbnail (:@type "inputFileLocal" :path ,frame1)
-                  :width 240
-                  :height 240)))))))
+     (list :@type "inputMessageVideoNote"
+           :video_note
+           (nconc
+            (list :@type "inputVideoNote"
+                  :video_note ifile
+                  :duration (round (telega-ffplay-get-duration i-filename))
+                  :length 240)
+            (when frame1
+              `(:thumbnail
+                (:@type "inputThumbnail"
+                        :thumbnail (:@type "inputFileLocal" :path ,frame1)
+                        :width 240
+                        :height 240))))))))
 
 (defun telega-chatbuf-attach-voice-note (as-file-p)
   "Attach a voice note to the chatbuf input.
@@ -5951,9 +5953,11 @@ voice-note.  Otherwise record voice note inplace.
          (i-filename (plist-get ifile :path)))
     (telega-chatbuf-input-insert
      (list :@type "inputMessageVoiceNote"
-           :waveform (telega-vvnote--waveform-for-file i-filename)
-           :duration (round (telega-ffplay-get-duration i-filename))
-           :voice_note ifile))))
+           :voice_note
+           (list :@type "inputVoiceNote"
+                 :voice_note ifile
+                 :duration (round (telega-ffplay-get-duration i-filename))
+                 :waveform (telega-vvnote--waveform-for-file i-filename))))))
 
 (defun telega-chatbuf--yank-media (mime-type data &optional doc-p)
   "Handler for the `yank-media' command."

--- a/telega-ins.el
+++ b/telega-ins.el
@@ -4211,8 +4211,13 @@ If SHORT-P is non-nil then use short version."
                     (telega-ins--self-destruct-type tl-ttl 'short)))
                  ))))
      (inputMessageVoiceNote
-      (let ((duration (or (plist-get imc :duration) 0))
-            (waveform (plist-get imc :waveform)))
+      ;; The duration and waveform sit inside the `inputVoiceNote' this is
+      ;; built with, but a draft keeps them flat -- `draftMessageContentVoiceNote'
+      ;; has no wrapper -- and drafts reach this same renderer as a fake imc.
+      ;; Falling back to IMC itself is what serves that caller.
+      (let* ((note (or (plist-get imc :voice_note) imc))
+             (duration (or (plist-get note :duration) 0))
+             (waveform (plist-get note :waveform)))
         (telega-ins "VoiceNote ")
         (when (and telega-use-images waveform)
           (telega-ins--image
@@ -4222,8 +4227,10 @@ If SHORT-P is non-nil then use short version."
         (telega-ins " (" (telega-duration-human-readable duration) ")")))
      (inputMessageVideoNote
       (telega-ins "VideoNote")
-      (let ((duration (or (plist-get imc :duration) 0))
-            (thumb-filename (telega--tl-get imc :thumbnail :thumbnail :path)))
+      ;; Flat for a draft, wrapped for an attachment; see the voice note above.
+      (let* ((note (or (plist-get imc :video_note) imc))
+             (duration (or (plist-get note :duration) 0))
+             (thumb-filename (telega--tl-get note :thumbnail :thumbnail :path)))
         (when (and telega-use-images thumb-filename)
           (telega-ins " ")
           (telega-ins--image

--- a/test.el
+++ b/test.el
@@ -86,7 +86,7 @@ Have Stoploss 690 Satoshi." :entities []))))
          :name (:@type "chatFolderName" :text (:@type "formattedText" :text "Emacs" :entities []))
          :icon (list :@type "chatFolderIcon" :name ""))
         ("ðŸ˜¹ðŸ˜¹ðŸ˜¹" :@type "chatFolderInfo" :id 3
-         :name (:@type "chatFolderName" :text (:@type "formattedText" :text #("í ½í¸¹í ½í¸¹í ½í¸¹" 0 2 (telega-emoji-p t telega-display "ðŸ˜¹") 2 4 (telega-emoji-p t telega-display "ðŸ˜¹") 4 6 (telega-emoji-p t telega-display "ðŸ˜¹")) :entities []) :animate_custom_emoji t)
+         :name (:@type "chatFolderName" :text (:@type "formattedText" :text #("ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½" 0 2 (telega-emoji-p t telega-display "ðŸ˜¹") 2 4 (telega-emoji-p t telega-display "ðŸ˜¹") 4 6 (telega-emoji-p t telega-display "ðŸ˜¹")) :entities []) :animate_custom_emoji t)
          :icon (list :@type "chatFolderIcon" :name ""))))
 
 
@@ -281,6 +281,58 @@ Have Stoploss 690 Satoshi." :entities []))))
         (should target)
         (button-activate button)
         (should (= (point) target))))))
+
+(ert-deftest telega-vvnote-tdlib-1.8.66-input-file ()
+  "Voice and video note attachments keep their file inside a wrapper."
+  (let ((ifile '(:@type "inputFileLocal" :path "/tmp/note.mp4")))
+    (should (equal ifile
+                   (telega-chatbuf--input-imc-file
+                    `(:@type "inputMessageVoiceNote"
+                             :voice_note (:@type "inputVoiceNote"
+                                                 :voice_note ,ifile
+                                                 :duration 3
+                                                 :waveform "AAAA")))))
+    (should (equal ifile
+                   (telega-chatbuf--input-imc-file
+                    `(:@type "inputMessageVideoNote"
+                             :video_note (:@type "inputVideoNote"
+                                                 :video_note ,ifile
+                                                 :duration 3
+                                                 :length 240)))))))
+
+(ert-deftest telega-vvnote-tdlib-1.8.66-one-line ()
+  "Input line reads a wrapped attachment, and a draft, which has no wrapper."
+  (let ((telega-use-images nil))
+    (cl-flet ((one-line (imc)
+                (with-temp-buffer
+                  (telega-ins--input-content-one-line imc)
+                  (buffer-substring-no-properties (point-min) (point-max)))))
+      (should (string-match-p
+               "VoiceNote.*(3s)"
+               (one-line '(:@type "inputMessageVoiceNote"
+                                  :voice_note (:@type "inputVoiceNote"
+                                                      :voice_note (:@type "inputFileLocal"
+                                                                          :path "/tmp/note.mp4")
+                                                      :duration 3
+                                                      :waveform "AAAA")))))
+      (should (string-match-p
+               "VideoNote.*(9s)"
+               (one-line '(:@type "inputMessageVideoNote"
+                                  :video_note (:@type "inputVideoNote"
+                                                      :video_note (:@type "inputFileLocal"
+                                                                          :path "/tmp/note.mp4")
+                                                      :duration 9
+                                                      :length 240)))))
+      ;; `draftMessageContentVoiceNote' and `draftMessageContentVideoNote' have
+      ;; no wrapper, and reach this same function as a fake imc.
+      (should (string-match-p
+               "VoiceNote.*(7s)"
+               (one-line '(:@type "inputMessageVoiceNote"
+                                  :duration 7 :waveform "AAAA"))))
+      (should (string-match-p
+               "VideoNote.*(11s)"
+               (one-line '(:@type "inputMessageVideoNote"
+                                  :duration 11 :length 240)))))))
 
 (ert-deftest telega-org-formatting ()
   "Test org mode text formatting."


### PR DESCRIPTION
## Summary

TDLib moved voice and video note media fields into nested `inputVoiceNote` and `inputVideoNote` objects -- the same wrapping #583 handled for stickers. telega still constructed the legacy flat form, so `sendMessage` returned an error and the note disappeared from the input without being sent.

- Construct the nested `inputVoiceNote` / `inputVideoNote`, moving `duration`, `waveform`, `length` and `thumbnail` inside.
- Teach input-file extraction and the one-line input preview about the nested structure.

TDLib changes:

- [Add td_api::inputVoiceNote](https://github.com/tdlib/td/commit/bfc292bd52a1ef248b1a4873b935a0bf090e0a96)
- [Add td_api::inputVideoNote](https://github.com/tdlib/td/commit/2caa367404282001c32a9d72911a8d1a60805db1)

## Root cause

`telega-chatbuf-attach-voice-note` built `inputMessageVoiceNote` with `voice_note`, `duration` and `waveform` at the top level. TDLib reads the single `voice_note` field as an `inputVoiceNote`, so the `inputFileLocal` was parsed as the wrapper -- no file inside, duration 0, empty waveform -- and rejected it:

```
error { code = 400 message = "InputFile is not specified" }
```

The rejection is silent. `sendMessage` is synchronous unless `telega-chat-send-messages-async` is set, so the error is returned rather than delivered through the event loop, while the input is cleared either way. Only the preview path, which passes a callback and is therefore asynchronous, surfaced it at all.

Two call sites move with the construction:

- `telega-chatbuf--input-imc-file` must descend one level further, as it already does for the types wrapped earlier, or the preliminary upload started for the attachment is never cancelled.
- `telega-ins--input-content-one-line` prefers the wrapper and falls back to the content itself, because `draftMessageContentVoiceNote` / `draftMessageContentVideoNote` keep these fields flat and reach the same renderer as a fake imc.

## Tests

Added ERT coverage:

- input-file extraction from wrapped voice and video note content
- one-line input preview for both the wrapped attachment and the flat draft shape

Both new tests fail on `master` and pass with this change.

- `make compile` with Emacs 30.2: clean, no new warnings
- `make test_el`: **25 tests passed, 0 unexpected**

Voice notes verified end to end against TDLib 1.8.66 -- recorded, sent, and played back. Video notes are not exercised; the schema change is the same one and the affected code paths are shared.
