### PR TITLE
Fix CAPF search bounds outside chat input

### DIFF
--- a/telega-completions.el
+++ b/telega-completions.el
@@ -505,6 +505,7 @@ Handles repeated leading CHARs (e.g. @@).  Returns nil if not applicable."
 (defun telega-capf--botcmd-bounds ()
   "Return (START . END) if point is in a /command at start of chatbuf input."
   (when (and telega-chatbuf--input-marker
+             (>= (point) telega-chatbuf--input-marker)
              (save-excursion
                (re-search-backward "/[^ ]*" telega-chatbuf--input-marker t))
              (= (match-beginning 0) telega-chatbuf--input-marker))
@@ -516,22 +517,23 @@ Non-nil ALLOW-SPACES-P allows spaces for the closed (having trailing
 colon) emoji."
   (let ((end (point))
         (bound (or bound (1- telega-chatbuf--input-marker))))
-    (save-excursion
-      ;; NOTE: rx in emacs-28 does not support `space'
-      ;; as character set, thats why we don't use rx
-      (when (and (or (re-search-backward
-                      ;;  (rx (or bol space) (group
-                      ;;   ":" (1+ (not (or space ":"))) (? ":")))
-                      "\\(?:^\\|[[:space:]]\\)\\(:[^:[:space:]]+:?\\)"
-                      bound 'no-error)
-                     ;; Try closed emoji if spaces allowed
-                     (and allow-spaces-p
-                          (re-search-backward
-                           ;; (rx (or bol space) (group ":" (1+ (not ":"))) ":")
-                           "\\(?:^\\|[[:space:]]\\)\\(:[^:]+\\):"
-                           bound 'no-error)))
-                 (equal end (match-end 0)))
-        (cons (match-beginning 1) end)))))
+    (when (<= bound end)
+      (save-excursion
+        ;; NOTE: rx in emacs-28 does not support `space'
+        ;; as character set, thats why we don't use rx
+        (when (and (or (re-search-backward
+                        ;;  (rx (or bol space) (group
+                        ;;   ":" (1+ (not (or space ":"))) (? ":")))
+                        "\\(?:^\\|[[:space:]]\\)\\(:[^:[:space:]]+:?\\)"
+                        bound 'no-error)
+                       ;; Try closed emoji if spaces allowed
+                       (and allow-spaces-p
+                            (re-search-backward
+                             ;; (rx (or bol space) (group ":" (1+ (not ":"))) ":")
+                             "\\(?:^\\|[[:space:]]\\)\\(:[^:]+\\):"
+                             bound 'no-error)))
+                   (equal end (match-end 0)))
+          (cons (match-beginning 1) end))))))
 
 ;;; CAPF: local emoji (:<name>:)
 (defun telega-capf-emoji ()

--- a/test.el
+++ b/test.el
@@ -387,6 +387,24 @@ Have Stoploss 690 Satoshi." :entities []))))
           (should (equal (nth 2 capf)
                          '(":rocket:"))))))))
 
+(ert-deftest telega-capf-ignores-history-before-input ()
+  "CAPFs should return nil when point precedes the chat input."
+  (with-temp-buffer
+    (insert " :rocket")
+    (let ((history-end (point)))
+      (insert "\n> ")
+      (setq-local telega-chatbuf--input-marker (point-marker))
+      (goto-char history-end)
+      (cl-letf (((symbol-function 'telega-emoji-init) #'ignore))
+        (should-not (telega-capf-emoji)))))
+  (with-temp-buffer
+    (insert "/help")
+    (let ((history-end (point)))
+      (insert "\n")
+      (setq-local telega-chatbuf--input-marker (point-marker))
+      (goto-char history-end)
+      (should-not (telega-capf-botcmd)))))
+
 (ert-deftest telega-bot-chat-with-topics-is-forum ()
   "Bot chats with topics enabled should reuse forum topic support."
   (let* ((bot-id 90901)


### PR DESCRIPTION
## Summary

- Return nil from emoji completion when its backward-search bound is after point.
- Return nil from bot-command completion when point is before the chat input marker.
- Add a regression test for both public CAPFs outside the chat input.

## Problem

With automatic CAPF frontends such as Corfu, completion can be requested while point is in the chat history, for example around an asynchronous chat-buffer redraw. The emoji and bot-command bounds helpers then pass a search bound to `re-search-backward` that is on the wrong side of point, which signals:

```text
Invalid search bound (wrong side of point)
```

Outside the input area these CAPFs should simply return nil.

## Verification

- `make test_el` — 24/24 ERT tests passed.
- Focused regression reproduced the error before the fix and passed afterward.
- `telega-completions.el` byte compilation and `check-parens` passed.
