### PR TITLE
Generate correct fake imcs for voice and video note drafts

### DIFF
--- a/telega-ins.el
+++ b/telega-ins.el
@@ -4211,11 +4211,7 @@ If SHORT-P is non-nil then use short version."
                     (telega-ins--self-destruct-type tl-ttl 'short)))
                  ))))
      (inputMessageVoiceNote
-      ;; The duration and waveform sit inside the `inputVoiceNote' this is
-      ;; built with, but a draft keeps them flat -- `draftMessageContentVoiceNote'
-      ;; has no wrapper -- and drafts reach this same renderer as a fake imc.
-      ;; Falling back to IMC itself is what serves that caller.
-      (let* ((note (or (plist-get imc :voice_note) imc))
+      (let* ((note (plist-get imc :voice_note))
              (duration (or (plist-get note :duration) 0))
              (waveform (plist-get note :waveform)))
         (telega-ins "VoiceNote ")
@@ -4227,8 +4223,7 @@ If SHORT-P is non-nil then use short version."
         (telega-ins " (" (telega-duration-human-readable duration) ")")))
      (inputMessageVideoNote
       (telega-ins "VideoNote")
-      ;; Flat for a draft, wrapped for an attachment; see the voice note above.
-      (let* ((note (or (plist-get imc :video_note) imc))
+      (let* ((note (plist-get imc :video_note))
              (duration (or (plist-get note :duration) 0))
              (thumb-filename (telega--tl-get note :thumbnail :thumbnail :path)))
         (when (and telega-use-images thumb-filename)
@@ -4359,14 +4354,32 @@ If SHORT-P is non-nil then use short version."
 (defun telega-ins--draft-content-one-line (draft-content)
   "Insert DRAFT-CONTENT for one line usage."
   (let* ((content-type (telega--tl-type draft-content))
-         (imc-type (cl-case content-type
-                     (draftMessageContentText "inputMessageText")
-                     (draftMessageContentVoiceNote "inputMessageVoiceNote")
-                     (draftMessageContentVideoNote "inputMessageVideoNote"))))
-    (cond (imc-type
-           (let ((fake-imc (copy-sequence draft-content)))
-             (plist-put fake-imc :@type imc-type)
-             (telega-ins--input-content-one-line fake-imc)))
+         (fake-imc
+          (cl-case content-type
+            (draftMessageContentText
+             (let ((imc (copy-sequence draft-content)))
+               (plist-put imc :@type "inputMessageText")))
+            ;; A note's file, duration, waveform and length are flat in the
+            ;; draft and nested in the input message content it stands for, so
+            ;; these are moved into the wrapper rather than relabelled.
+            (draftMessageContentVoiceNote
+             (list :@type "inputMessageVoiceNote"
+                   :voice_note
+                   (list :@type "inputVoiceNote"
+                         :voice_note (list :@type "inputFileLocal"
+                                           :path (plist-get draft-content :file_path))
+                         :duration (plist-get draft-content :duration)
+                         :waveform (plist-get draft-content :waveform))))
+            (draftMessageContentVideoNote
+             (list :@type "inputMessageVideoNote"
+                   :video_note
+                   (list :@type "inputVideoNote"
+                         :video_note (list :@type "inputFileLocal"
+                                           :path (plist-get draft-content :file_path))
+                         :duration (plist-get draft-content :duration)
+                         :length (plist-get draft-content :length)))))))
+    (cond (fake-imc
+           (telega-ins--input-content-one-line fake-imc))
           ((eq content-type 'draftMessageContentRichMessage)
            (telega-ins--one-lined
             (telega-ins--rich-message (plist-get draft-content :message))))

--- a/test.el
+++ b/test.el
@@ -301,11 +301,15 @@ Have Stoploss 690 Satoshi." :entities []))))
                                                  :length 240)))))))
 
 (ert-deftest telega-vvnote-tdlib-1.8.66-one-line ()
-  "Input line reads a wrapped attachment, and a draft, which has no wrapper."
+  "Input line reads a wrapped attachment, and a draft converted into one."
   (let ((telega-use-images nil))
     (cl-flet ((one-line (imc)
                 (with-temp-buffer
                   (telega-ins--input-content-one-line imc)
+                  (buffer-substring-no-properties (point-min) (point-max))))
+              (draft-line (draft-content)
+                (with-temp-buffer
+                  (telega-ins--draft-content-one-line draft-content)
                   (buffer-substring-no-properties (point-min) (point-max)))))
       (should (string-match-p
                "VoiceNote.*(3s)"
@@ -323,16 +327,18 @@ Have Stoploss 690 Satoshi." :entities []))))
                                                                           :path "/tmp/note.mp4")
                                                       :duration 9
                                                       :length 240)))))
-      ;; `draftMessageContentVoiceNote' and `draftMessageContentVideoNote' have
-      ;; no wrapper, and reach this same function as a fake imc.
+      ;; A draft keeps these fields flat, and is rendered by the same function
+      ;; after `telega-ins--draft-content-one-line' has nested them.
       (should (string-match-p
                "VoiceNote.*(7s)"
-               (one-line '(:@type "inputMessageVoiceNote"
-                                  :duration 7 :waveform "AAAA"))))
+               (draft-line '(:@type "draftMessageContentVoiceNote"
+                                    :file_path "/tmp/note.mp4"
+                                    :duration 7 :waveform "AAAA"))))
       (should (string-match-p
                "VideoNote.*(11s)"
-               (one-line '(:@type "inputMessageVideoNote"
-                                  :duration 11 :length 240)))))))
+               (draft-line '(:@type "draftMessageContentVideoNote"
+                                    :file_path "/tmp/note.mp4"
+                                    :duration 11 :length 240)))))))
 
 (ert-deftest telega-org-formatting ()
   "Test org mode text formatting."


### PR DESCRIPTION
## Summary

Follow-up to #593, doing what you described: drafts now generate a correct fake imc, so the fallback to the content itself can go.

- `telega-ins--draft-content-one-line` nests a note's `file_path`, `duration`, `waveform` and `length` into `inputVoiceNote` / `inputVideoNote` instead of relabelling the draft's `:@type` and passing the flat fields through.
- `telega-ins--input-content-one-line` now reads only the wrapper for both note kinds.

Relabelling also never produced an `InputFile` -- a draft carries `file_path`, a plain string -- so the wrapper is built with the `inputFileLocal` it should have had.

## Tests

`telega-vvnote-tdlib-1.8.66-one-line` now drives the draft cases through `telega-ins--draft-content-one-line` with real `draftMessageContentVoiceNote` / `draftMessageContentVideoNote`, rather than the hand-built flat imc it used before -- so it covers the conversion rather than the tolerance that replaced it.

Verified the coverage is real: with the renderer made strict but the old relabelling left in place, the draft cases fail.

- `make compile` with Emacs 30.2: clean, no new warnings
- `make test_el`: **26 tests passed, 0 unexpected**
