### PR TITLE
Return the cached topic from telega-topic--ensure

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -2039,8 +2039,8 @@ View only if message matches TEMEX or not yet viewed."
                (lambda-with-current-buffer (_ignored)
                  (telega--getForumTopic telega-chatbuf--chat topic-id
                    (lambda-with-current-buffer (topic)
-                     (telega-topic--ensure topic telega-chatbuf--chat)
-                     (setq telega-chatbuf--topic topic)
+                     (setq telega-chatbuf--topic
+                           (telega-topic--ensure topic telega-chatbuf--chat))
                      (telega-chatbuf--chat-update "topic-update"))))))
 
             ;; NOTE: updated thread info does not change its

--- a/telega-topic.el
+++ b/telega-topic.el
@@ -168,13 +168,17 @@
       telega-topic-brackets))
 
 (defun telega-topic--ensure (topic &optional chat)
-  "Ensure TOPIC for CHAT is stored in the `telega--chat-topics'."
+  "Ensure TOPIC for CHAT is stored in the `telega--chat-topics'.
+Return the stored topic, which for an already known topic is the object
+in the cache rather than TOPIC."
   (unless chat
     (setq chat (telega-topic-chat topic)))
 
   (if-let ((existing-topic (telega-topic-get chat (telega-topic-id topic))))
       ;; Update topic inplace
-      (setcdr existing-topic (cdr topic))
+      (progn
+        (setcdr existing-topic (cdr topic))
+        (setq topic existing-topic))
     (setf (alist-get (telega-topic-id topic) (telega-chat-topics-alist chat))
           topic))
 

--- a/test.el
+++ b/test.el
@@ -483,6 +483,31 @@ Have Stoploss 690 Satoshi." :entities []))))
       (remhash bot-id users-ht)
       (remhash chat-id telega--chats))))
 
+(ert-deftest telega-topic-ensure-returns-cached-topic ()
+  "Ensuring a known topic returns the cached object, not the fresh one.
+Callers keep the result and compare topics with `eq', so handing back the
+argument would leave them holding an object the cache does not use."
+  (let* ((chat-id -1001)
+         (topic-id 7)
+         (chat `(:@type "chat" :id ,chat-id))
+         (make-topic
+          (lambda (unread)
+            `(:@type "forumTopic"
+                     :info (:@type "forumTopicInfo"
+                                   :chat_id ,chat-id
+                                   :forum_topic_id ,topic-id)
+                     :unread_count ,unread))))
+    (unwind-protect
+        (cl-letf (((symbol-function 'telega-chat--forum-topics-icons-fetch)
+                   #'ignore))
+          (let* ((cached (telega-topic--ensure (funcall make-topic 1) chat))
+                 (again (telega-topic--ensure (funcall make-topic 9) chat)))
+            (should (eq cached (telega-topic-get chat topic-id)))
+            (should (eq again cached))
+            ;; The fresh data still lands in the cached object.
+            (should (= 9 (plist-get cached :unread_count)))))
+      (remhash chat-id telega--chat-topics))))
+
 (ert-deftest telega-msg-open-thread-or-topic-fetches-forum-topic ()
   "Opening a forum topic message should fetch missing topic info."
   (let* ((bot-id 90911)


### PR DESCRIPTION
`telega-topic--ensure` folds a freshly received topic into the object already in
`telega--chat-topics` with `setcdr`, so the cache deliberately keeps its identity
across updates. But it returns its *argument*, not the object it just updated. A
caller that keeps the result is then holding a cons the cache does not use — equal
in content, no longer `eq` to it.

`telega-chatbuf--topic` is set from exactly that return value, in the
`getForumTopic` callback after viewing messages, and topics are compared by
identity in three places, so from that moment:

- **`is-current-in-chatbuf` answers no for the very topic the chatbuf is filtered
  by.** The default `telega-msg-temex-show-topic` is
  `(and (chat is-forum) (topic (not is-current-in-chatbuf)))`, so every message in
  a topic-narrowed forum chatbuf gets labelled with the topic it is already
  showing. This is the one I actually noticed while working on an unrelated feature.
- **`telega--on-updateForumTopic` stops recognising the chatbuf's topic**
  (`telega-tdlib-events.el:1772`) and no longer calls
  `telega-chatbuf--input-draft-update`, so the topic's draft stops being restored.
- **`telega-chatbuf-filter-by-topic`** (`telega-chat.el:7409`) redoes filtering it
  had already applied.

The fix returns the stored object, and has the chatbuf adopt what it is given
rather than the object it passed in. `test.el` already relies on this identity
where it asserts that `telega-msg-topic` and `telega-topic-get` agree, so this
makes `telega-topic--ensure` keep the invariant the tests already assume.

There is a fourth `eq` comparison at `telega-tdlib-events.el:1736`, but it sits
inside `(when nil ...)`, so I left it alone.

### Test

`telega-topic-ensure-returns-cached-topic` ensures a topic twice and checks that
the second call returns the cached object and that the fresh data still lands in
it. It fails on master and passes with the change; the existing 26 stay green.
