### PR TITLE
Derive a supergroup's chat id the way TDLib does

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -213,12 +213,17 @@ If OFFLINE-P is non-nil then do not request the telega-server."
                  (throw 'found chat)))
              telega--chats)))
 
+(defun telega-chat--id-by-supergroup-id (supergroup-id)
+  "Return chat id for the supergroup with SUPERGROUP-ID.
+Chat id is TDLib's ZERO_CHANNEL_ID minus SUPERGROUP-ID, see DialogId.h."
+  (- -1000000000000 supergroup-id))
+
 (defun telega-chat-by-supergroup (supergroup)
   "Return chat by SUPERGROUP."
   (or
    ;; Try very fast heuristic first
-   (telega-chat-get (string-to-number
-                     (format "-100%S" (plist-get supergroup :id)))
+   (telega-chat-get (telega-chat--id-by-supergroup-id
+                     (plist-get supergroup :id))
                     'offline)
    ;; Fallback to full scan
    (telega-chat-by (lambda (chat)

--- a/telega-tdlib-events.el
+++ b/telega-tdlib-events.el
@@ -1192,7 +1192,7 @@ messages."
     ;; Check number of the admins has been changed, it might be not up
     ;; to date, see https://github.com/tdlib/td/issues/1040
     (when-let ((chat (telega-chat-get
-                      (string-to-number (format "-100%d" supergroup-id))
+                      (telega-chat--id-by-supergroup-id supergroup-id)
                       'offline)))
       ;; TODO: Might affect root's buffer view
       ;; NOTE: chatbuf might need to be updated, since for example

--- a/test.el
+++ b/test.el
@@ -463,6 +463,16 @@ Have Stoploss 690 Satoshi." :entities []))))
       (goto-char history-end)
       (should-not (telega-capf-botcmd)))))
 
+(ert-deftest telega-supergroup-chat-id ()
+  "Chat id is TDLib's ZERO_CHANNEL_ID minus the supergroup id."
+  ;; Ten digit ids, where appending to \"-100\" happens to give the same answer.
+  (should (= -1001234567890 (telega-chat--id-by-supergroup-id 1234567890)))
+  (should (= -1009876543210 (telega-chat--id-by-supergroup-id 9876543210)))
+  ;; Ids of any other length, where it does not.  Telegram issues supergroup
+  ;; ids past ZERO_CHANNEL_ID's magnitude nowadays.
+  (should (= -2000000000000 (telega-chat--id-by-supergroup-id 1000000000000)))
+  (should (= -1000001234567 (telega-chat--id-by-supergroup-id 1234567))))
+
 (ert-deftest telega-bot-chat-with-topics-is-forum ()
   "Bot chats with topics enabled should reuse forum topic support."
   (let* ((bot-id 90901)


### PR DESCRIPTION
telega builds a supergroup's chat id by writing the id after `"-100"` and reading
it back as a number:

```elisp
(string-to-number (format "-100%S" (plist-get supergroup :id)))
```

TDLib subtracts (`DialogId.h`, `DialogId.cpp`):

```cpp
static constexpr int64 ZERO_CHANNEL_ID = -1000000000000ll;
id = ZERO_CHANNEL_ID - channel_id.get();
```

Those agree only when the supergroup id is exactly ten digits — true for every id
when the code was written, no longer true now that Telegram issues ids past 10¹²:

| supergroup id | TDLib chat id | concatenated |
|---|---|---|
| 1234567890 | -1001234567890 | -1001234567890 ✓ |
| **1000000000000** | **-2000000000000** | -1001000000000000 ✗ |
| **1234567** | **-1000001234567** | -1001234567 ✗ |

On an account I checked this against, 60 of 411 supergroups had an id in the
failing range. Every supergroup chat in the table matched the arithmetic
derivation; 351 of 411 matched the concatenation.

### Two consequences

**`telega-chat-by-supergroup`** survives it — when the lookup misses it falls back
to `telega-chat-by`, which scans the whole chat table. That is why this went
unnoticed, and it costs a full `maphash` per update for each affected supergroup
(≈1.4 ms over a table of ~1400 chats).

**`telega--on-updateSupergroupFullInfo`** has no fallback:

```elisp
(when-let ((chat (telega-chat-get (string-to-number (format "-100%d" supergroup-id)) 'offline)))
  (telega-chat--mark-dirty chat event)
  ...
  (telega-chatbuf--admins-fetch)
```

For an affected supergroup the `when-let` never binds, so the chat is never marked
dirty and the administrator list is never refetched.

The fix derives the id once, arithmetically, and uses it in both places.

### Test

`telega-chat-id-by-supergroup-id` pins the boundary: ten-digit ids, where the old
concatenation happened to agree, and longer and shorter ones, where it did not.
